### PR TITLE
Merge marked testing into the dev branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
     - pip install -i http://tools.pacificclimate.org/pypiserver/ -r requirements.txt -r test_requirements.txt -r data_format_requirements.txt
     - pip install -i http://tools.pacificclimate.org/pypiserver/ .
 script:
-    - py.test -vv --tb=short tests
+    - py.test -vv --tb=short -m "not crmpdb and not bulk_data" tests

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -3,6 +3,8 @@
    instantiates all of the responder applications and binds them to various PathDispatchers.
 '''
 
+__all__ = ['get_config', 'wrap_auth']
+
 import os
 from os.path import dirname
 import atexit
@@ -11,7 +13,6 @@ from pkg_resources import resource_filename, resource_stream, get_distribution
 from tempfile import mkdtemp
 from shutil import rmtree
 import yaml
-
 import static
 from beaker.middleware import SessionMiddleware
 

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -63,7 +63,7 @@ def get_config():
     return config
 
 def clean_session_dir(session_dir, should_I):
-    if should_I:
+    if should_I and os.path.exists(session_dir):
         print('Removing session directory {}'.format(session_dir))
         rmtree(session_dir)
 

--- a/pdp/main.py
+++ b/pdp/main.py
@@ -1,0 +1,99 @@
+'''Exposes globally defined WSGI apps as module variables
+'''
+import atexit
+from os.path import dirname
+from pkg_resources import resource_filename
+
+import static
+from beaker.middleware import SessionMiddleware
+from werkzeug.wsgi import DispatcherMiddleware
+
+#from pdp import get_config, wrap_auth, clean_session_dir
+from pdp import wrap_auth, clean_session_dir
+
+from pdp.error import ErrorMiddleware
+from pdp.dispatch import PathDispatcher
+from pdp_util.auth import check_authorized_return_email
+from ga_wsgi_client import AnalyticsMiddleware
+
+import portals.pcds as pcds
+from portals.pcds import portal as pcds_portal
+from portals.pcds import data_server as pcds_data_server
+
+import portals.bc_prism as bc_prism
+from portals.bc_prism import portal as bc_prism_portal
+from portals.bc_prism import data_server as bc_prism_data_server
+
+import portals.hydro_stn as hydro_stn
+from portals.hydro_stn import portal as hydro_stn_portal
+from portals.hydro_stn import data_server as hydro_stn_data_server
+
+import portals.bcsd_downscale_canada as bcsd_canada
+from portals.bcsd_downscale_canada import portal as bcsd_canada_portal
+from portals.bcsd_downscale_canada import data_server as bcsd_canada_data_server
+
+import portals.bccaq_extremes as bccaq_extremes
+from portals.bccaq_extremes import portal as bccaq_extremes_portal
+from portals.bccaq_extremes import data_server as bccaq_extremes_data_server
+
+import portals.vic_gen1 as vic_gen1
+from portals.vic_gen1 import portal as vic_gen1_portal
+from portals.vic_gen1 import data_server as vic_gen1_data_server
+
+#global_config = get_config()
+#dsn = global_config['dsn']
+#pcds_dsn = global_config['pcds_dsn']
+#atexit.register(clean_session_dir, global_config['session_dir'], global_config['clean_session_dir'])
+
+def initialize_frontend(global_config, use_auth=False, use_analytics=False):
+    '''Frontend server with all portal pages and required resources
+    '''
+
+    docs_app = static.Cling(dirname(__file__) + '/../doc')
+    static_app = static.Cling(resource_filename('pdp', 'static'))
+    check_auth = wrap_auth(check_authorized_return_email, required=False)
+
+    wsgi_app = PathDispatcher([
+        ('^/css/(default|pcic).css$', static.Cling(resource_filename('pdp_util', 'data'))), # a bit of a hack for now
+        ('^/check_auth_app/?$', check_auth),
+        ('^/{}/.*$'.format(pcds.url_base), pcds_portal(global_config)),
+        ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_portal(global_config)),
+        ('^/{}/.*$'.format(bc_prism.url_base), bc_prism_portal(global_config)),
+        ('^/{}/.*$'.format(vic_gen1.url_base), vic_gen1_portal(global_config)),
+        ('^/{}/.*$'.format(bcsd_canada.url_base), bcsd_canada_portal(global_config)),
+        ('^/{}/.*$'.format(bccaq_extremes.url_base), bccaq_extremes_portal(global_config)),
+        ('^/docs/.*$', docs_app),
+        ], default=static_app)
+
+    if use_analytics:
+        wsgi_app = AnalyticsMiddleware(wsgi_app, global_config['analytics'])
+    if use_auth:
+        wsgi_app = SessionMiddleware(wsgi_app, auto=1, data_dir=global_config['session_dir'])
+        atexit.register(clean_session_dir, global_config['session_dir'], global_config['clean_session_dir'])
+    return ErrorMiddleware(wsgi_app)
+
+
+def initialize_backend(global_config, use_auth=False, use_analytics=False):
+    '''Backend pathdispatcher with all data servers
+    '''
+    wsgi_app = PathDispatcher([
+        ('^/{}/.*$'.format(bc_prism.url_base), bc_prism_data_server(global_config, bc_prism.ensemble_name)),
+        ('^/{}/.*$'.format(bcsd_canada.url_base), bcsd_canada_data_server(global_config, bcsd_canada.ensemble_name)),
+        ('^/{}/.*$'.format(vic_gen1.url_base), vic_gen1_data_server(global_config, vic_gen1.ensemble_name)),
+        ('^/{}/.*$'.format(bccaq_extremes.url_base), bccaq_extremes_data_server(global_config, bccaq_extremes.ensemble_name)),
+        ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_data_server(global_config)),
+        ('^/{}/.*$'.format(pcds.url_base), pcds_data_server(global_config))
+    ])
+    if use_analytics:
+        wsgi_app = AnalyticsMiddleware(wsgi_app, global_config['analytics'])
+    if use_auth:
+        wsgi_app = SessionMiddleware(wsgi_app, auto=1, data_dir=global_config['session_dir'])
+        atexit.register(clean_session_dir, global_config['session_dir'], global_config['clean_session_dir'])
+    return ErrorMiddleware(wsgi_app)
+
+def initialize_dev_server(global_config, use_auth=False, use_analytics=False):
+  '''Development server
+  '''
+  return DispatcherMiddleware(initialize_frontend(global_config, use_auth, use_analytics), {
+    '/data': initialize_backend(global_config, use_auth, use_analytics)
+  })

--- a/pdp/portals/hydro_stn.yaml
+++ b/pdp/portals/hydro_stn.yaml
@@ -2,5 +2,5 @@ name: hydro-station-data-server
 version: 0
 api_version: 0
 handlers:
-    - url: hydro_stn
+    - url: data/hydro_stn
       dir: /home/data/projects/hydrology/vic_gen1_followup/vic_gen1_routed

--- a/pdp/wsgi.py
+++ b/pdp/wsgi.py
@@ -1,85 +1,14 @@
 '''Exposes globally defined WSGI apps as module variables
 '''
-import atexit
-from os.path import dirname
-from pkg_resources import resource_filename
-
-import static
-from beaker.middleware import SessionMiddleware
 from werkzeug.wsgi import DispatcherMiddleware
 
-from pdp import get_config, wrap_auth, clean_session_dir
-
-from pdp.error import ErrorMiddleware
-from pdp.dispatch import PathDispatcher
-from pdp_util.auth import check_authorized_return_email
-from ga_wsgi_client import AnalyticsMiddleware
-
-import portals.pcds as pcds
-from portals.pcds import portal as pcds_portal
-from portals.pcds import data_server as pcds_data_server
-
-import portals.bc_prism as bc_prism
-from portals.bc_prism import portal as bc_prism_portal
-from portals.bc_prism import data_server as bc_prism_data_server
-
-import portals.hydro_stn as hydro_stn
-from portals.hydro_stn import portal as hydro_stn_portal
-from portals.hydro_stn import data_server as hydro_stn_data_server
-
-import portals.bcsd_downscale_canada as bcsd_canada
-from portals.bcsd_downscale_canada import portal as bcsd_canada_portal
-from portals.bcsd_downscale_canada import data_server as bcsd_canada_data_server
-
-import portals.bccaq_extremes as bccaq_extremes
-from portals.bccaq_extremes import portal as bccaq_extremes_portal
-from portals.bccaq_extremes import data_server as bccaq_extremes_data_server
-
-import portals.vic_gen1 as vic_gen1
-from portals.vic_gen1 import portal as vic_gen1_portal
-from portals.vic_gen1 import data_server as vic_gen1_data_server
+from pdp import get_config
+from pdp.main import initialize_frontend, initialize_backend
 
 global_config = get_config()
-dsn = global_config['dsn']
-pcds_dsn = global_config['pcds_dsn']
-atexit.register(clean_session_dir, global_config['session_dir'], global_config['clean_session_dir'])
 
-check_auth = wrap_auth(check_authorized_return_email, required=False)
-docs_app = static.Cling(dirname(__file__) + '/../doc')
-static_app = static.Cling(resource_filename('pdp', 'static'))
-
-## Backend pathdispatcher with all data servers
-backend = PathDispatcher([
-    ('^/{}/.*$'.format(bc_prism.url_base), bc_prism_data_server(global_config, bc_prism.ensemble_name)),
-    ('^/{}/.*$'.format(bcsd_canada.url_base), bcsd_canada_data_server(global_config, bcsd_canada.ensemble_name)),
-    ('^/{}/.*$'.format(vic_gen1.url_base), vic_gen1_data_server(global_config, vic_gen1.ensemble_name)),
-    ('^/{}/.*$'.format(bccaq_extremes.url_base), bccaq_extremes_data_server(global_config, bccaq_extremes.ensemble_name)),
-    ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_data_server(global_config)),
-    ('^/{}/.*$'.format(pcds.url_base), pcds_data_server(global_config))
-    ])
-
-## Frontend server with all portal pages and required resources
-frontend = PathDispatcher([
-    ('^/css/(default|pcic).css$', static.Cling(resource_filename('pdp_util', 'data'))), # a bit of a hack for now
-    ('^/check_auth_app/?$', check_auth),
-    ('^/{}/.*$'.format(pcds.url_base), pcds_portal(global_config)),
-    ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_portal(global_config)),
-    ('^/{}/.*$'.format(bc_prism.url_base), bc_prism_portal(global_config)),
-    ('^/{}/.*$'.format(vic_gen1.url_base), vic_gen1_portal(global_config)),
-    ('^/{}/.*$'.format(bcsd_canada.url_base), bcsd_canada_portal(global_config)),
-    ('^/{}/.*$'.format(bccaq_extremes.url_base), bccaq_extremes_portal(global_config)),
-    ('^/docs/.*$', docs_app),
-    ], default=static_app)
-
-## Development server
+frontend = initialize_frontend(global_config)
+backend = initialize_backend(global_config)
 dev_server = DispatcherMiddleware(frontend, {
     '/data': backend
 })
-
-backend = AnalyticsMiddleware(backend, global_config['analytics'])
-backend = SessionMiddleware(backend, auto=1, data_dir=global_config['session_dir'])
-backend = ErrorMiddleware(backend)
-
-frontend = AnalyticsMiddleware(frontend, global_config['analytics'])
-frontend = SessionMiddleware(frontend, auto=1, data_dir=global_config['session_dir'])
-frontend = ErrorMiddleware(frontend)

--- a/pdp/wsgi.py
+++ b/pdp/wsgi.py
@@ -57,9 +57,6 @@ backend = PathDispatcher([
     ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_data_server(global_config)),
     ('^/{}/.*$'.format(pcds.url_base), pcds_data_server(global_config))
     ])
-backend = AnalyticsMiddleware(backend, global_config['analytics'])
-backend = SessionMiddleware(backend, auto=1, data_dir=global_config['session_dir'])
-backend = ErrorMiddleware(backend)
 
 ## Frontend server with all portal pages and required resources
 frontend = PathDispatcher([
@@ -74,14 +71,15 @@ frontend = PathDispatcher([
     ('^/docs/.*$', docs_app),
     ], default=static_app)
 
-frontend = AnalyticsMiddleware(frontend, global_config['analytics'])
-frontend = SessionMiddleware(frontend, auto=1, data_dir=global_config['session_dir'])
-frontend = ErrorMiddleware(frontend)
-
 ## Development server
 dev_server = DispatcherMiddleware(frontend, {
     '/data': backend
 })
-dev_server = AnalyticsMiddleware(dev_server, global_config['analytics'])
-dev_server = SessionMiddleware(dev_server, auto=1, data_dir=global_config['session_dir'])
-dev_server = ErrorMiddleware(dev_server)
+
+backend = AnalyticsMiddleware(backend, global_config['analytics'])
+backend = SessionMiddleware(backend, auto=1, data_dir=global_config['session_dir'])
+backend = ErrorMiddleware(backend)
+
+frontend = AnalyticsMiddleware(frontend, global_config['analytics'])
+frontend = SessionMiddleware(frontend, auto=1, data_dir=global_config['session_dir'])
+frontend = ErrorMiddleware(frontend)

--- a/scripts/cherry_serve.py
+++ b/scripts/cherry_serve.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     basicConfig(format='%(levelname)s:%(name)s:%(asctime)s %(message)s', stream=sys.stdout, level=DEBUG)
 
     server = wsgiserver.CherryPyWSGIServer(
-        ('0.0.0.0', args.port), main
+        ('0.0.0.0', args.port), main()
         )
     try:
         server.start()

--- a/scripts/cherry_serve.py
+++ b/scripts/cherry_serve.py
@@ -3,11 +3,11 @@ from logging import basicConfig, DEBUG
 from argparse import ArgumentParser
 
 from cherrypy import wsgiserver
-from pdp import main
+from pdp.wsgi import dev_server
 
 if __name__ == '__main__':
 
-    parser = ArgumentParser(description='Start a development pdp:main Flask instance')
+    parser = ArgumentParser(description='Start a development pdp.wsgi:dev_server Flask instance')
     parser.add_argument('-p', '--port', type=int, required=True,
                         help='Indicate the port on which to bind the application')
     args = parser.parse_args()
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     basicConfig(format='%(levelname)s:%(name)s:%(asctime)s %(message)s', stream=sys.stdout, level=DEBUG)
 
     server = wsgiserver.CherryPyWSGIServer(
-        ('0.0.0.0', args.port), main()
+        ('0.0.0.0', args.port), dev_server
         )
     try:
         server.start()

--- a/scripts/eventlet_serve.py
+++ b/scripts/eventlet_serve.py
@@ -15,4 +15,4 @@ if __name__ == '__main__':
 
     basicConfig(format='%(levelname)s:%(name)s:%(asctime)s %(message)s', stream=sys.stdout, level=DEBUG)
     
-    wsgi.server(eventlet.listen(('0.0.0.0', args.port)), main, debug=True)
+    wsgi.server(eventlet.listen(('0.0.0.0', args.port)), main(), debug=True)

--- a/scripts/eventlet_serve.py
+++ b/scripts/eventlet_serve.py
@@ -4,15 +4,15 @@ from logging import basicConfig, DEBUG
 import eventlet
 from eventlet import wsgi
 
-from pdp import main
+from pdp.wsgi import dev_server
 
 if __name__ == '__main__':
 
-    parser = ArgumentParser(description='Start a development pdp:main Flask instance')
+    parser = ArgumentParser(description='Start a development pdp.wsgi:dev_server Flask instance')
     parser.add_argument('-p', '--port', type=int, required=True,
                         help='Indicate the port on which to bind the application')
     args = parser.parse_args()
 
     basicConfig(format='%(levelname)s:%(name)s:%(asctime)s %(message)s', stream=sys.stdout, level=DEBUG)
     
-    wsgi.server(eventlet.listen(('0.0.0.0', args.port)), main(), debug=True)
+    wsgi.server(eventlet.listen(('0.0.0.0', args.port)), dev_server, debug=True)

--- a/scripts/gevent_serve.py
+++ b/scripts/gevent_serve.py
@@ -4,7 +4,7 @@ from logging import basicConfig, DEBUG
 from gevent import pywsgi
 from gevent.monkey import patch_all; patch_all()
 
-from pdp import main
+from pdp.wsgi import dev_server
 
 if __name__ == '__main__':
 
@@ -16,5 +16,5 @@ if __name__ == '__main__':
     basicConfig(format='%(levelname)s:%(name)s:%(asctime)s %(message)s', stream=sys.stdout, level=DEBUG)
     
     print 'Starting server on port {}'.format(args.port)
-    server = pywsgi.WSGIServer(('0.0.0.0', args.port), main())
+    server = pywsgi.WSGIServer(('0.0.0.0', args.port), dev_server)
     server.serve_forever()

--- a/scripts/gevent_serve.py
+++ b/scripts/gevent_serve.py
@@ -16,5 +16,5 @@ if __name__ == '__main__':
     basicConfig(format='%(levelname)s:%(name)s:%(asctime)s %(message)s', stream=sys.stdout, level=DEBUG)
     
     print 'Starting server on port {}'.format(args.port)
-    server = pywsgi.WSGIServer(('0.0.0.0', args.port), main)
+    server = pywsgi.WSGIServer(('0.0.0.0', args.port), main())
     server.serve_forever()

--- a/scripts/gevent_serve_multiprocess.py
+++ b/scripts/gevent_serve_multiprocess.py
@@ -148,7 +148,7 @@ if __name__ == '__main__':
     listener = _tcp_listener(('0.0.0.0', args.port))
     
     def serve_forever(listener):
-        pywsgi.WSGIServer(listener, main).serve_forever()
+        pywsgi.WSGIServer(listener, main()).serve_forever()
     
     if args.processors == 0:
         num_proc = cpu_count() * 2 + 1

--- a/scripts/gevent_serve_multiprocess.py
+++ b/scripts/gevent_serve_multiprocess.py
@@ -7,7 +7,7 @@ from gevent.baseserver import _tcp_listener
 from gevent import pywsgi
 from gevent.monkey import patch_all; patch_all()
 
-from pdp import main
+from pdp.wsgi import dev_server
 
 if __name__ == '__main__':
     '''
@@ -136,7 +136,7 @@ if __name__ == '__main__':
     
     '''
     
-    parser = ArgumentParser(description='Start a development pdp:main Flask instance')
+    parser = ArgumentParser(description='Start a development pdp.wsgi:dev_server Flask instance')
     parser.add_argument('-p', '--port', type=int, required=True,
                         help='Indicate the port on which to bind the application')
     parser.add_argument('--processors', type=int, required=True,
@@ -148,7 +148,7 @@ if __name__ == '__main__':
     listener = _tcp_listener(('0.0.0.0', args.port))
     
     def serve_forever(listener):
-        pywsgi.WSGIServer(listener, main()).serve_forever()
+        pywsgi.WSGIServer(listener, dev_server).serve_forever()
     
     if args.processors == 0:
         num_proc = cpu_count() * 2 + 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,10 +25,6 @@ def session_dir(request):
     request.addfinalizer(lambda: dirname.remove(rec=1, ignore_errors=True))
     return str(dirname)
 
-@pytest.fixture(scope="module")
-def static_url_space():
-    return frontend
-
 @pytest.fixture(scope="function")
 def raster_pydap():
     from pdp.portals.bcsd_downscale_canada import portal

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -17,9 +17,9 @@ from numpy.testing import assert_almost_equal
 from bs4 import BeautifulSoup
 
 @pytest.mark.parametrize('url', ['/js/crmp_map.js', '/css/main.css', '/images/banner.png'])
-def test_static(static_url_space, url):
+def test_static(pcic_data_portal, url):
     req = Request.blank(url)
-    resp = req.get_response(static_url_space)
+    resp = req.get_response(pcic_data_portal)
     assert resp.status == '200 OK'
 
 @pytest.mark.crmpdb

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -28,6 +28,7 @@ def test_am_authorized(pcic_data_portal, authorized_session_id):
     resp = req.get_response(pcic_data_portal)
     assert resp.status == '200 OK'
 
+@pytest.mark.crmpdb
 @pytest.mark.parametrize(('url', 'title', 'body_strings'), [
                          ('/data/pcds/lister/', 'PCDS Data', ["Climatological calculations", "raw/"]),
                          ('/data/pcds/lister/raw/', "Participating CRMP Networks", ["FLNRO-WMB/", "Environment Canada (Canadian Daily Climate Data 2007)"]),
@@ -55,6 +56,7 @@ def test_unsupported_extension(pcic_data_portal, authorized_session_id):
     resp = req.get_response(pcic_data_portal)
     assert resp.status == '400 Bad Request'
 
+@pytest.mark.crmpdb
 @pytest.mark.parametrize('ext', ['ascii', 'csv'])
 def test_ascii_response(pcic_data_portal, authorized_session_id, ext):
     req = Request.blank('/data/pcds/lister/climo/EC/1010066.csql.{0}?station_observations.Precip_Climatology,station_observations.time'.format(ext))
@@ -78,6 +80,7 @@ Precip_Climatology, time
 '''
     assert resp.body == x
 
+@pytest.mark.crmpdb
 def test_xls_response(pcic_data_portal, authorized_session_id):
     req = Request.blank('/data/pcds/lister/climo/EC/1010066.csql.xls?station_observations.Precip_Climatology,station_observations.time')
     req.cookies['beaker.session.id'] = authorized_session_id
@@ -94,6 +97,7 @@ def test_xls_response(pcic_data_portal, authorized_session_id):
     assert attributes.cell_value(1, 2) == '1010066' # station_id
     assert attributes.cell_value(7, 2) == 'ACTIVE PASS' # station name
 
+@pytest.mark.crmpdb
 def test_nc_response(pcic_data_portal, authorized_session_id):
     req = Request.blank('/data/pcds/lister/climo/EC/1010066.csql.nc?station_observations.Precip_Climatology,station_observations.time')
     req.cookies['beaker.session.id'] = authorized_session_id
@@ -117,6 +121,7 @@ def test_nc_response(pcic_data_portal, authorized_session_id):
     nc.close()
     os.remove(f.name)
 
+@pytest.mark.crmpdb
 def test_nc_response_with_null_values(pcic_data_portal, authorized_session_id):
     req = Request.blank('/data/pcds/lister/raw/BCH/AKI.rsql.nc')
     req.cookies['beaker.session.id'] = authorized_session_id
@@ -124,6 +129,7 @@ def test_nc_response_with_null_values(pcic_data_portal, authorized_session_id):
     assert resp.status == '200 OK'
     assert resp.content_type == 'application/x-netcdf'
 
+@pytest.mark.crmpdb
 def test_clip_to_date_one(pcic_data_portal, authorized_session_id):
     base_url = '/data/pcds/agg/?'
     sdate, edate = datetime(2007, 01, 01), None
@@ -172,6 +178,7 @@ def test_clip_to_date_one(pcic_data_portal, authorized_session_id):
 #     resp = req.get_response(pcic_data_portal)
 #     assert resp.status == '200 OK'
 
+@pytest.mark.crmpdb
 @pytest.mark.parametrize(('filters', 'expected'), [
     ({'network-name': 'EC_raw'}, 4),
     ({'from-date': '2000/01/01', 'to-date': '2000/01/31'}, 14),
@@ -193,6 +200,7 @@ def test_station_counts(filters, expected, pcic_data_portal):
     # data = json.loads(resp.body)
     # assert data['stations_selected'] == expected
 
+@pytest.mark.crmpdb
 @pytest.mark.parametrize('filters', [
     {'network-name': 'EC_raw'},
     {'from-date': '2000/01/01', 'to-date': '2000/01/31'},
@@ -209,6 +217,7 @@ def test_record_length(filters, pcic_data_portal):
     assert 'stations_selected' in resp.body
 
 
+@pytest.mark.crmpdb
 @pytest.mark.parametrize(('network', 'color'), [
     ('flnro-wmb.png', (12, 102, 0)), # Forest Green
     ('bch.png', (0, 16, 165)), # Blue
@@ -234,6 +243,7 @@ def test_legend(network, color, pcic_data_portal):
     assert average == color
     os.remove(f.name)
     
+@pytest.mark.crmpdb
 def test_legend_caching(pcic_data_portal):
     url = '/pcds/images/legend/flnro-wmb.png'
     
@@ -296,6 +306,7 @@ def test_climatology_bounds(pcic_data_portal, authorized_session_id):
     nc.close()
     os.remove(f.name)
 
+@pytest.mark.bulk_data
 @pytest.mark.parametrize('url', [
     '/data/downscaled_gcms/pr+tasmax+tasmin_day_BCSD+ANUSPLIN300+CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc.aig?tasmax[0:30][77:138][129:238]&', # has NODATA values
     '/data/downscaled_gcms/pr+tasmax+tasmin_day_BCSD+ANUSPLIN300+CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc.aig?tasmax[0:30][144:236][307:348]&',

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,7 +23,7 @@ def test_static(static_url_space, url):
     assert resp.status == '200 OK'
 
 @pytest.mark.crmpdb
-@pytest.mark.parametrize('url', ['/', '/pcds_map/', '/apps/count_stations/'])
+@pytest.mark.parametrize('url', ['/', '/pcds/map/', '/pcds/count_stations/'])
 def test_no_404s(pcic_data_portal, url):
     req = Request.blank(url)
     resp = req.get_response(pcic_data_portal)
@@ -330,9 +330,10 @@ def test_aaigrid_response(pcic_data_portal, authorized_session_id, url):
     assert resp.content_type == 'application/zip'
 
 @pytest.mark.bulk_data
-def test_hydro_stn_data_catalog(pcic_data_portal):
+def test_hydro_stn_data_catalog(pcic_data_portal, authorized_session_id):
     url = '/data/hydro_stn/catalog.json'
     req = Request.blank(url)
+    req.cookies['beaker.session.id'] = authorized_session_id
     resp = req.get_response(pcic_data_portal)
     assert resp.status == '200 OK'
     assert resp.content_type == 'application/json'

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -9,6 +9,7 @@ import netCDF4
 def test_can_instantiate_raster_pydap(raster_pydap):
     assert isinstance(raster_pydap, object)
 
+@pytest.mark.bulk_data
 def test_hdf5_to_netcdf(pcic_data_portal, authorized_session_id):
     req = Request.blank('/data/downscaled_gcms/pr+tasmax+tasmin_day_BCSD+ANUSPLIN300+CCSM4_historical+rcp26_r2i1p1_19500101-21001231.nc.nc?pr[0:1:1][116:167][84:144]&')
     req.cookies['beaker.session.id'] = authorized_session_id
@@ -26,6 +27,7 @@ def test_hdf5_to_netcdf(pcic_data_portal, authorized_session_id):
     nc.close()
     os.remove(f.name)
 
+@pytest.mark.bulk_data
 def test_prism_response(pcic_data_portal, authorized_session_id):
     req = Request.blank('/data/bc_prism/tmin_monClim_PRISM_historical_run1_197101-200012.nc.html')
     req.cookies['beaker.session.id'] = authorized_session_id
@@ -33,6 +35,7 @@ def test_prism_response(pcic_data_portal, authorized_session_id):
     assert resp.status == '200 OK'
     assert resp.content_type == 'text/html'
     
+@pytest.mark.bulk_data
 def test_dds_response(pcic_data_portal, authorized_session_id):
     req = Request.blank('/data/downscaled_gcms/pr+tasmax+tasmin_day_BCSD+ANUSPLIN300+CCSM4_historical+rcp26_r2i1p1_19500101-21001231.nc.dds')
     req.cookies['beaker.session.id'] = authorized_session_id


### PR DESCRIPTION
I have created a branch of `pdp` that has all tests with external dependencies marked (e.g. bulk NetCDF that are not appropriate for revision control), which allows for running a subset of them outside of a PCIC environment (e.g. TravisCI or AWS).

I *believe* that this branch is ready to be merged into `dev`, but it would be good to have a second set of eyes on it just to make sure. There are a couple changes to the overall application structure, so I don't want to shoot us in the foot, so close to 2.3.0 deployment.

The changes include:

* Tests requiring the CRMP database are marked "crmpdb" and tests requiring external bulk data are marked "bulk_data". One can exclude this set of tests by running `py.test -m "not crmpdb and not bulk_data" tests` (this is now the default under TravisCI).
* I have moved all of the top-level WSGI application construction to *functions* in the `pdp.main`. Then I have retained *instantiation* of those functions in the `pdp.wsgi` module. This allows us to import `pdp.main` in testing modes and instantiate the applications without analytics or authentication wrappers. But the instantiated versions can still be passed over to `flask` or `gunicorn` or other application servers that require an instantiated WSGI application.
* I have changed the configuration reading code from looking for `config.yaml` as a package resource to reading the `PDP_CONFIG` environment variable. This allows us to install pdp prior to configuration and/or maintain multiple config sets (with the package or otherwise) which can be executed independently. This requires an extra deploy step, so you need to be aware of it.

I've deployed this branch to a VirtualBox instance and all 50 of 50 tests pass (after the usual tweaks to `config.yaml`), so I *think* it's good to go. But take a look, and if it looks good, just merge the pull request.