### PR TITLE
Merge Hotfix/2.3.4 evented ncwms capabilies. Fixes #32.

### DIFF
--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -34,9 +34,18 @@ $(document).ready(function () {
             dlLink.onExtensionChange($(this).val());
         }
     );
-    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
-    ncwmsLayer.events.register('change', dlLink, dlLink.onBoxChange);
+
+    ncwmsLayer.events.register('change', dlLink, function () {
+        getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
+            if (selectionLayer.features.length > 0) {
+                dlLink.onBoxChange({feature: selectionLayer.features[0]});
+            }
+        });
+    });
+    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
+
     dlLink.register($('#download-timeseries'), function (node) {
         node.attr('href', dlLink.getUrl());
     }

--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -8,7 +8,7 @@ var catalog, ensemble_name, ncwmsCapabilities, ncwms;
 
 $(document).ready(function () {
     var map, clickHandler, loginButton, ncwmsLayer, selectionLayer,
-        dlLink, mdLink, catalogUrl, request;
+        dlLink, mdLink, catalogUrl, catalog_request;
 
     map = init_raster_map();
     clickHandler = getOLClickHandler(map);
@@ -21,7 +21,7 @@ $(document).ready(function () {
     selectionLayer = map.getSelectionLayer();
 
     catalogUrl = "../catalog/catalog.json";
-    request = $.ajax(catalogUrl, { dataType: "json"});
+    catalog_request = $.ajax(catalogUrl, { dataType: "json"});
 
     document.getElementById("pdp-controls").appendChild(getRasterControls(pdp.ensemble_name));
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(false));
@@ -82,7 +82,7 @@ $(document).ready(function () {
 
     ncwms.events.register('change', ncwms, getTimeIndex);
 
-    request.then(function (data) {
+    catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
         processNcwmsLayerMetadata(ncwmsLayer);
         // Set the data URL as soon as it is available

--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -4,7 +4,7 @@
 "use strict";
 
 // Globals
-var catalog, ensemble_name, current_dataset, ncwmsCapabilities, ncwms;
+var catalog, ensemble_name, ncwmsCapabilities, ncwms;
 
 $(document).ready(function () {
     var map, clickHandler, loginButton, ncwmsLayer, selectionLayer,

--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -4,11 +4,11 @@
 "use strict";
 
 // Globals
-var catalog, ensemble_name, ncwmsCapabilities, ncwms;
+var ensemble_name, ncwmsCapabilities, ncwms;
 
 $(document).ready(function () {
     var map, clickHandler, loginButton, ncwmsLayer, selectionLayer,
-        dlLink, mdLink, catalogUrl, catalog_request;
+        dlLink, mdLink, catalogUrl, catalog_request, catalog;
 
     map = init_raster_map();
     clickHandler = getOLClickHandler(map);
@@ -36,6 +36,7 @@ $(document).ready(function () {
     );
 
     ncwmsLayer.events.register('change', dlLink, function () {
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
             if (selectionLayer.features.length > 0) {
                 dlLink.onBoxChange({feature: selectionLayer.features[0]});
@@ -84,7 +85,7 @@ $(document).ready(function () {
 
     catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
-        processNcwmsLayerMetadata(ncwmsLayer);
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         // Set the data URL as soon as it is available
         dlLink.onLayerChange();
         mdLink.onLayerChange();

--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -40,7 +40,7 @@ $(document).ready(function () {
             }
         });
     });
-    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
 
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
 

--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -3,9 +3,6 @@
 
 "use strict";
 
-// Globals
-var ensemble_name, ncwmsCapabilities, ncwms;
-
 $(document).ready(function () {
     var map, clickHandler, loginButton, ncwmsLayer, selectionLayer,
         dlLink, mdLink, catalogUrl, catalog_request, catalog;

--- a/pdp/static/js/bccaq_extremes_controls.js
+++ b/pdp/static/js/bccaq_extremes_controls.js
@@ -1,9 +1,7 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, d3, pdp, map, DOMParser, handle_ie8_xml, getRasterNativeProj, ncwmsCapabilities, getRasterBbox, rasterBBoxToIndicies, intersection*/
+/*global $, jQuery, OpenLayers, d3, pdp, map, ncwms, DOMParser, handle_ie8_xml, getRasterNativeProj, ncwmsCapabilities, getRasterBbox, rasterBBoxToIndicies, intersection*/
 
 "use strict";
-
-var ncwms, catalog;
 
 function getPlotWindow() {
     var frag = document.createDocumentFragment(),

--- a/pdp/static/js/bccaq_extremes_controls.js
+++ b/pdp/static/js/bccaq_extremes_controls.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-var ncwms, catalog, current_dataset;
+var ncwms, catalog;
 
 function getPlotWindow() {
     var frag = document.createDocumentFragment(),

--- a/pdp/static/js/bccaq_extremes_map.js
+++ b/pdp/static/js/bccaq_extremes_map.js
@@ -6,7 +6,7 @@
 //var pcds_map; // global so that it's accessible across documents
 // NOTE: variables 'gs_url' is expected to be set before this is call
 // Do this in the sourcing html
-var pcds_map, gs_url, map, ncwms;
+var pcds_map, gs_url, map;
 
 function init_raster_map() {
 
@@ -121,7 +121,7 @@ function init_raster_map() {
     };
 
     datalayerName = "Climate raster";
-    ncwms =  new OpenLayers.Layer.WMS(
+    var ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         ncwms_params(defaults.dataset + "/" + defaults.variable),
@@ -158,10 +158,6 @@ function init_raster_map() {
     ncwms.events.register('change', ncwms, set_map_title);
     ncwms.events.triggerEvent('change', defaults.dataset + "/" + defaults.variable);
 
-    (function (globals) {
-        globals.ncwms = ncwms;
-    }(window));
-
     map.addLayers(
         [
             ncwms,
@@ -180,6 +176,10 @@ function init_raster_map() {
     map.getSelectionLayer = function () {
         return map.getLayersByName(selLayerName)[0];
     };
+
+    (function (globals) {
+        globals.ncwms = ncwms;
+    }(window));
 
     return map;
 }

--- a/pdp/static/js/bccaq_extremes_map.js
+++ b/pdp/static/js/bccaq_extremes_map.js
@@ -3,14 +3,9 @@
 
 "use strict";
 
-//var pcds_map; // global so that it's accessible across documents
-// NOTE: variables 'gs_url' is expected to be set before this is call
-// Do this in the sourcing html
-var pcds_map, gs_url, map;
-
 function init_raster_map() {
 
-    var options, mapControls, selLayerName, selectionLayer, panelControls,
+    var map, options, mapControls, selLayerName, selectionLayer, panelControls,
         na_osm, defaults, datalayerName, cb;
 
     function ncwms_params(layer_name, colorscale_min, colorscale_max) {

--- a/pdp/static/js/bccaq_extremes_map.js
+++ b/pdp/static/js/bccaq_extremes_map.js
@@ -6,7 +6,7 @@
 //var pcds_map; // global so that it's accessible across documents
 // NOTE: variables 'gs_url' is expected to be set before this is call
 // Do this in the sourcing html
-var pcds_map, gs_url, current_dataset, map, ncwms;
+var pcds_map, gs_url, map, ncwms;
 
 function init_raster_map() {
 
@@ -134,8 +134,6 @@ function init_raster_map() {
             tileSize: new OpenLayers.Size(512, 512)
         }
     );
-
-    current_dataset = ncwms.params.layers;
 
     cb = new Colorbar("pdpColorbar", ncwms);
 

--- a/pdp/static/js/bccaq_extremes_map.js
+++ b/pdp/static/js/bccaq_extremes_map.js
@@ -6,7 +6,7 @@
 function init_raster_map() {
 
     var map, options, mapControls, selLayerName, selectionLayer, panelControls,
-        na_osm, defaults, datalayerName, cb;
+        na_osm, defaults, datalayerName, cb, ncwms;
 
     function ncwms_params(layer_name, colorscale_min, colorscale_max) {
         var params, varname, c_range, prec_range, percent_data, number_days_data,
@@ -116,7 +116,7 @@ function init_raster_map() {
     };
 
     datalayerName = "Climate raster";
-    var ncwms =  new OpenLayers.Layer.WMS(
+    ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         ncwms_params(defaults.dataset + "/" + defaults.variable),

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -4,10 +4,10 @@
 "use strict";
 
 // Globals
-var ensemble_name, ncwmsCapabilities, catalog;
+var ensemble_name, ncwmsCapabilities;
 
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, dlLink, mdLink;
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog, dlLink, mdLink;
 
     map = init_raster_map();
     loginButton = pdp.init_login("login-div");
@@ -31,6 +31,7 @@ $(document).ready(function () {
     );
 
     ncwmsLayer.events.register('change', dlLink, function () {
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
             if (selectionLayer.features.length > 0) {
                 dlLink.onBoxChange({feature: selectionLayer.features[0]});
@@ -66,7 +67,7 @@ $(document).ready(function () {
 
     catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
-        processNcwmsLayerMetadata(ncwmsLayer);
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         // Set the data URL as soon as it is available
         dlLink.onLayerChange();
         mdLink.onLayerChange();

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -3,9 +3,6 @@
 
 "use strict";
 
-// Globals
-var ensemble_name, ncwmsCapabilities;
-
 $(document).ready(function () {
     var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog, dlLink, mdLink;
 

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -4,7 +4,7 @@
 "use strict";
 
 // Globals
-var ensemble_name, current_dataset, ncwmsCapabilities, catalog;
+var ensemble_name, ncwmsCapabilities, catalog;
 
 $(document).ready(function () {
     var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, request, dlLink, mdLink;

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -7,7 +7,7 @@
 var ensemble_name, ncwmsCapabilities, catalog;
 
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, request, dlLink, mdLink;
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, dlLink, mdLink;
 
     map = init_raster_map();
     loginButton = pdp.init_login("login-div");
@@ -17,7 +17,7 @@ $(document).ready(function () {
     selectionLayer = map.getSelectionLayer();
 
     catalogUrl = "../catalog/catalog.json";
-    request = $.ajax(catalogUrl, {dataType: "json"});
+    catalog_request = $.ajax(catalogUrl, {dataType: "json"});
 
     document.getElementById("pdp-controls").appendChild(getRasterControls(pdp.ensemble_name));
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
@@ -64,7 +64,7 @@ $(document).ready(function () {
         }
     );
 
-    request.then(function (data) {
+    catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
         processNcwmsLayerMetadata(ncwmsLayer);
         // Set the data URL as soon as it is available

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -35,7 +35,7 @@ $(document).ready(function () {
             }
         });
     });
-    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
 
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
 

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -29,9 +29,18 @@ $(document).ready(function () {
             dlLink.onExtensionChange($(this).val());
         }
     );
-    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
-    ncwmsLayer.events.register('change', dlLink, dlLink.onBoxChange);
+
+    ncwmsLayer.events.register('change', dlLink, function () {
+        getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
+            if (selectionLayer.features.length > 0) {
+                dlLink.onBoxChange({feature: selectionLayer.features[0]});
+            }
+        });
+    });
+    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
+
     dlLink.register($('#download-timeseries'), function (node) {
         node.attr('href', dlLink.getUrl());
     }

--- a/pdp/static/js/canada_ex_app.js
+++ b/pdp/static/js/canada_ex_app.js
@@ -4,7 +4,8 @@
 "use strict";
 
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog, dlLink, mdLink;
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog,
+        dlLink, mdLink, capabilities_request, ncwms_capabilities;
 
     map = init_raster_map();
     loginButton = pdp.init_login("login-div");
@@ -15,6 +16,8 @@ $(document).ready(function () {
 
     catalogUrl = "../catalog/catalog.json";
     catalog_request = $.ajax(catalogUrl, {dataType: "json"});
+
+    capabilities_request = getNCWMSLayerCapabilities(ncwmsLayer);
 
     document.getElementById("pdp-controls").appendChild(getRasterControls(pdp.ensemble_name));
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
@@ -29,15 +32,22 @@ $(document).ready(function () {
 
     ncwmsLayer.events.register('change', dlLink, function () {
         processNcwmsLayerMetadata(ncwmsLayer, catalog);
-        getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
+        capabilities_request = getNCWMSLayerCapabilities(ncwmsLayer);
+        capabilities_request.done(function(data) {
+            ncwms_capabilities = data;
             if (selectionLayer.features.length > 0) {
-                dlLink.onBoxChange({feature: selectionLayer.features[0]});
+                dlLink.onBoxChange({feature: selectionLayer.features[0]}, ncwms_capabilities);
             }
         });
     });
     ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
 
-    selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
+    selectionLayer.events.register('featureadded', dlLink, function (selection){
+        capabilities_request.done(function(data) {
+            ncwms_capabilities = data;
+            dlLink.onBoxChange(selection, data);
+        });
+    });
 
     dlLink.register($('#download-timeseries'), function (node) {
         node.attr('href', dlLink.getUrl());
@@ -62,6 +72,9 @@ $(document).ready(function () {
         }
     );
 
+    capabilities_request.done(function (data) {
+        ncwms_capabilities = data;
+    });
     catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
         processNcwmsLayerMetadata(ncwmsLayer, catalog);

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -11,7 +11,7 @@ var pcds_map, gs_url;
 function init_raster_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
         map, na_osm, defaults, params,
-        datalayerName, ncwms, cb;
+        datalayerName, cb;
 
     // Map Config
     options = na4326_map_options();
@@ -48,7 +48,7 @@ function init_raster_map() {
     };
 
     datalayerName = "Climate raster";
-    ncwms =  new OpenLayers.Layer.WMS(
+    var ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         params,
@@ -76,10 +76,6 @@ function init_raster_map() {
         }
     }
     ncwms.events.register('change', ncwms, customize_wms_params);
-
-    (function (globals) {
-        globals.ncwms = ncwms;
-    }(window));
 
     map.addLayers(
         [
@@ -136,6 +132,10 @@ function init_raster_map() {
     });
 
     ncwms.events.triggerEvent('change', defaults.dataset + "/" + defaults.variable);
+
+    (function (globals) {
+        globals.ncwms = ncwms;
+    }(window));
 
     return map;
 }

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -6,7 +6,7 @@
 // globls
 // NOTE: variables 'gs_url' is expected to be set before this is call
 // Do this in the sourcing html
-var current_dataset, pcds_map, gs_url;
+var pcds_map, gs_url;
 
 function init_raster_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
@@ -61,8 +61,6 @@ function init_raster_map() {
             tileSize: new OpenLayers.Size(512, 512)
         }
     );
-
-    current_dataset = params.layers;
 
     function customize_wms_params(layer_name) {
         var varname = layer_name.split('/')[1];

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -3,11 +3,6 @@
 
 "use strict";
 
-// globls
-// NOTE: variables 'gs_url' is expected to be set before this is call
-// Do this in the sourcing html
-var pcds_map, gs_url;
-
 function init_raster_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
         map, na_osm, defaults, params,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -5,8 +5,7 @@
 
 function init_raster_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
-        map, na_osm, defaults, params,
-        datalayerName, cb;
+        map, na_osm, defaults, params, ncwms, datalayerName, cb;
 
     // Map Config
     options = na4326_map_options();
@@ -43,7 +42,7 @@ function init_raster_map() {
     };
 
     datalayerName = "Climate raster";
-    var ncwms =  new OpenLayers.Layer.WMS(
+    ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         params,

--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -279,7 +279,7 @@ RasterDownloadLink.prototype = {
         this.ext = ext;
         this.trigger();
     },
-    onBoxChange: function (selection) {
+    onBoxChange: function (selection, ncwmsCapabilities) {
         var lyr_id, raster_proj, selection_proj,
             raster_bnds, selection_bnds, that;
         lyr_id = this.layer.params.LAYERS;

--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, processNcwmsLayerMetadata, createRasterFormatOptions, createDownloadLink, getRasterNativeProj, ncwmsCapabilities, getRasterBbox, rasterBBoxToIndicies, intersection, getTimeSelected*/
+/*global $, jQuery, createRasterFormatOptions, createDownloadLink, getRasterNativeProj, ncwmsCapabilities, getRasterBbox, rasterBBoxToIndicies, intersection, getTimeSelected*/
 "use strict";
 
 // globals
@@ -51,7 +51,6 @@ function generateMenuTree(subtree, leafNameMapping) {
             $('<a/>').text(linkText).click(function () {
                 ncwms.params.LAYERS = newlayer;
                 ncwms.events.triggerEvent('change', newlayer);
-                processNcwmsLayerMetadata(ncwms);
             }).addClass('menu-leaf').appendTo(li);
         }
         li.appendTo(ul);

--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -3,7 +3,7 @@
 "use strict";
 
 // globals
-var pdp, ncwms, current_dataset, map;
+var pdp, ncwms, map;
 
 function getDateRange() {
     var rangeDiv = pdp.createDiv("date-range");
@@ -51,7 +51,6 @@ function generateMenuTree(subtree, leafNameMapping) {
             $('<a/>').text(linkText).click(function () {
                 ncwms.params.LAYERS = newlayer;
                 ncwms.events.triggerEvent('change', newlayer);
-                current_dataset = newlayer;
                 processNcwmsLayerMetadata(ncwms);
             }).addClass('menu-leaf').appendTo(li);
         }

--- a/pdp/static/js/pdp_download.js
+++ b/pdp/static/js/pdp_download.js
@@ -46,14 +46,3 @@ function createDownloadLink(id, divClass, links) {
     });
     return downloadDiv;
 };
-
-function getCatalog(callback) {
-    $.ajax({'url': '../catalog/' + 'catalog.json',
-        'type': 'GET',
-        'dataType': 'json',
-        'success': function (data, textStatus, jqXHR) {
-            callback(data);
-        }
-        }
-        );
-}

--- a/pdp/static/js/pdp_raster_map.js
+++ b/pdp/static/js/pdp_raster_map.js
@@ -94,8 +94,7 @@ function getNCWMSLayerCapabilities(ncwms_layer) {
     })
     .fail(handle_ie8_xml)
     .always(function (response, status, jqXHR) {
-        window.ncwmsCapabilities = $(jqXHR.responseXML);
-        deferred.resolve();
+        deferred.resolve($(jqXHR.responseXML));
     });
 
     return deferred.promise();

--- a/pdp/static/js/pdp_raster_map.js
+++ b/pdp/static/js/pdp_raster_map.js
@@ -101,7 +101,7 @@ function getNCWMSLayerCapabilities(ncwms_layer) {
     return deferred.promise();
 }
 
-function processNcwmsLayerMetadata(ncwms_layer) {
+function processNcwmsLayerMetadata(ncwms_layer, catalog) {
 
     var layerUrl, maxTimeReq, unitsSinceReq;
 

--- a/pdp/static/js/pdp_raster_map.js
+++ b/pdp/static/js/pdp_raster_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global pdp, $, OpenLayers, catalog, setTimeAvailable, handle_ie8_xml, DOMParser
+/*global pdp, $, OpenLayers, setTimeAvailable, handle_ie8_xml, DOMParser
 */
 
 "use strict";

--- a/pdp/static/js/pdp_raster_map.js
+++ b/pdp/static/js/pdp_raster_map.js
@@ -79,26 +79,31 @@ function getNCWMSLayerCapabilities(ncwms_layer) {
     // and then have another fail() fallthrough handler .That is impossible, however.
     // see: http://domenic.me/2012/10/14/youre-missing-the-point-of-promises/
 
+    var deferred = $.Deferred();
+
     var params = {
         REQUEST: "GetCapabilities",
         SERVICE: "WMS",
         VERSION: "1.1.1",
         DATASET: ncwms_layer.params.LAYERS.split("/")[0]
     };
-    $.ajax({url: ncwms_layer.url,
-            data: params,
-           })
-        .fail(handle_ie8_xml)
-        .always(function (response, status, jqXHR) {
-            window.ncwmsCapabilities = $(jqXHR.responseXML);
-        });
+
+    $.ajax({
+        url: ncwms_layer.url,
+        data: params,
+    })
+    .fail(handle_ie8_xml)
+    .always(function (response, status, jqXHR) {
+        window.ncwmsCapabilities = $(jqXHR.responseXML);
+        deferred.resolve();
+    });
+
+    return deferred.promise();
 }
 
 function processNcwmsLayerMetadata(ncwms_layer) {
 
     var layerUrl, maxTimeReq, unitsSinceReq;
-
-    getNCWMSLayerCapabilities(ncwms_layer);
 
     // transform the data_server url into the un-authed catalog based url for metadata
     layerUrl = catalog[getNcwmsLayerId(ncwms_layer)];

--- a/pdp/static/js/pdp_vector_map.js
+++ b/pdp/static/js/pdp_vector_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global pdp, $, OpenLayers, catalog, setTimeAvailable, handle_ie8_xml, DOMParser
+/*global pdp, $, OpenLayers, setTimeAvailable, handle_ie8_xml, DOMParser
 */
 
 "use strict";

--- a/pdp/static/js/prism_demo_app.js
+++ b/pdp/static/js/prism_demo_app.js
@@ -36,9 +36,18 @@ $(document).ready(function () {
             dlLink.onExtensionChange($(this).val());
         }
     ).change(setBoundsInUrlTemplate);
-    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
-    ncwmsLayer.events.register('change', dlLink, dlLink.onBoxChange);
+
+    ncwmsLayer.events.register('change', dlLink, function () {
+        getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
+            if (selectionLayer.features.length > 0) {
+                dlLink.onBoxChange({feature: selectionLayer.features[0]});
+            }
+        });
+    });
+    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
+
     dlLink.register($('#download-timeseries'), function (node) {
         node.attr('href', dlLink.getUrl());
     });

--- a/pdp/static/js/prism_demo_app.js
+++ b/pdp/static/js/prism_demo_app.js
@@ -4,7 +4,7 @@
 "use strict";
 
 // Globals
-var ensemble_name, current_dataset, ncwmsCapabilities, catalog;
+var ensemble_name, ncwmsCapabilities, catalog;
 
 $(document).ready(function () {
     var map, loginButton, ncwmsLayer, selectionLayer, dlLink, mdLink;

--- a/pdp/static/js/prism_demo_app.js
+++ b/pdp/static/js/prism_demo_app.js
@@ -3,9 +3,6 @@
 
 "use strict";
 
-// Globals
-var ensemble_name, ncwmsCapabilities;
-
 $(document).ready(function () {
     var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog, dlLink, mdLink;
 

--- a/pdp/static/js/prism_demo_app.js
+++ b/pdp/static/js/prism_demo_app.js
@@ -1,13 +1,13 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, pdp, init_prism_map, getPRISMControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
+/*global $, jQuery, pdp, init_prism_map, processNcwmsLayerMetadata, getPRISMControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
 
 "use strict";
 
 // Globals
-var ensemble_name, ncwmsCapabilities, catalog;
+var ensemble_name, ncwmsCapabilities;
 
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, dlLink, mdLink;
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog, dlLink, mdLink;
 
     map = init_prism_map();
     loginButton = pdp.init_login('login-div');
@@ -41,6 +41,7 @@ $(document).ready(function () {
     ).change(setBoundsInUrlTemplate);
 
     ncwmsLayer.events.register('change', dlLink, function () {
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
             if (selectionLayer.features.length > 0) {
                 dlLink.onBoxChange({feature: selectionLayer.features[0]});
@@ -67,7 +68,7 @@ $(document).ready(function () {
 
     catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
-        processNcwmsLayerMetadata(ncwmsLayer);
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         // Set the data URL as soon as it is available
         dlLink.onLayerChange();
         mdLink.onLayerChange();

--- a/pdp/static/js/prism_demo_app.js
+++ b/pdp/static/js/prism_demo_app.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
             }
         });
     });
-    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
 
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
 

--- a/pdp/static/js/prism_demo_app.js
+++ b/pdp/static/js/prism_demo_app.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, pdp, init_prism_map, getCatalog, getPRISMControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
+/*global $, jQuery, pdp, init_prism_map, getPRISMControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
 
 "use strict";
 
@@ -7,7 +7,7 @@
 var ensemble_name, ncwmsCapabilities, catalog;
 
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer, dlLink, mdLink;
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, dlLink, mdLink;
 
     map = init_prism_map();
     loginButton = pdp.init_login('login-div');
@@ -18,6 +18,9 @@ $(document).ready(function () {
 
     ncwmsLayer = map.getClimateLayer();
     selectionLayer = map.getSelectionLayer();
+
+    catalogUrl = "../catalog/catalog.json";
+    catalog_request = $.ajax(catalogUrl, {dataType: "json"});
 
     // Ensure that climatology_bounds are included in non-aig data downloads
     function setBoundsInUrlTemplate() {
@@ -62,14 +65,12 @@ $(document).ready(function () {
         node.attr('href', mdLink.getUrl());
     });
 
-    // FIXME: This needs to have error handling and this is horrible
-    getCatalog(
-        function (data) {
-            catalog = dlLink.catalog = mdLink.catalog = data;
-            // Set the data URL as soon as it is available
-            dlLink.onLayerChange();
-            mdLink.onLayerChange();
-        }
-    );
+    catalog_request.done(function (data) {
+        catalog = dlLink.catalog = mdLink.catalog = data;
+        processNcwmsLayerMetadata(ncwmsLayer);
+        // Set the data URL as soon as it is available
+        dlLink.onLayerChange();
+        mdLink.onLayerChange();
+    });
 
 });

--- a/pdp/static/js/prism_demo_controls.js
+++ b/pdp/static/js/prism_demo_controls.js
@@ -3,9 +3,6 @@
 
 "use strict";
 
-//globals
-var catalog;
-
 function getPRISMControls(ensemble_name) {
     var div, form, fieldset, varMapping;
 

--- a/pdp/static/js/prism_demo_controls.js
+++ b/pdp/static/js/prism_demo_controls.js
@@ -4,7 +4,7 @@
 "use strict";
 
 //globals
-var catalog, current_dataset;
+var catalog;
 
 function getPRISMControls(ensemble_name) {
     var div, form, fieldset, varMapping;

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, BC3005_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getBC3005Bounds, getNCWMSLayerCapabilities, getBC3005OsmBaseLayer, getOpacitySlider, Colorbar*/
+/*global $, jQuery, OpenLayers, pdp, BC3005_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getBC3005Bounds, getBC3005OsmBaseLayer, getOpacitySlider, Colorbar*/
 
 "use strict";
 
@@ -57,8 +57,6 @@ function init_prism_map() {
             tileSize: new OpenLayers.Size(512, 512)
         }
     );
-
-    getNCWMSLayerCapabilities(ncwms); // async save into global var ncwmsCapabilities
 
     function set_map_title(layer_name) {
         // 'this' must be bound to the ncwms layer object

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -6,7 +6,7 @@
 // NOTE: variables 'gs_url', 'ncwms_url', 'tilecache_url' is expected to be set before this is call
 // Do this in the sourcing html
 // globals
-var gs_url, ncwms_url, tilecache_url, ncwms;
+var gs_url, ncwms_url, tilecache_url;
 
 function init_prism_map() {
     var selectionLayer, options, mapControls, selLayerName, panelControls,
@@ -44,7 +44,7 @@ function init_prism_map() {
 
 
     datalayerName = "Climate raster";
-    ncwms =  new OpenLayers.Layer.WMS(
+    var ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         params,
@@ -123,6 +123,11 @@ function init_prism_map() {
 
     ncwms.events.register('change', ncwms, set_map_title);
     ncwms.events.triggerEvent('change', defaults.dataset + "/" + defaults.variable);
+
+    // Expose ncwms as a global
+    (function (globals) {
+        globals.ncwms = ncwms;
+    }(window));
 
     return map;
 }

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -6,7 +6,7 @@
 // NOTE: variables 'gs_url', 'ncwms_url', 'tilecache_url' is expected to be set before this is call
 // Do this in the sourcing html
 // globals
-var gs_url, ncwms_url, tilecache_url, current_dataset, ncwms;
+var gs_url, ncwms_url, tilecache_url, ncwms;
 
 function init_prism_map() {
     var selectionLayer, options, mapControls, selLayerName, panelControls,
@@ -59,7 +59,6 @@ function init_prism_map() {
     );
 
     getNCWMSLayerCapabilities(ncwms); // async save into global var ncwmsCapabilities
-    current_dataset = params.layers;
 
     function set_map_title(layer_name) {
         // 'this' must be bound to the ncwms layer object

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -5,7 +5,7 @@
 
 function init_prism_map() {
     var selectionLayer, options, mapControls, selLayerName, panelControls,
-        map, defaults, params, datalayerName, cb;
+        map, defaults, params, datalayerName, cb, ncwms;
 
     // Map Config
     options = BC3005_map_options();
@@ -39,7 +39,7 @@ function init_prism_map() {
 
 
     datalayerName = "Climate raster";
-    var ncwms =  new OpenLayers.Layer.WMS(
+    ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         params,

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -3,11 +3,6 @@
 
 "use strict";
 
-// NOTE: variables 'gs_url', 'ncwms_url', 'tilecache_url' is expected to be set before this is call
-// Do this in the sourcing html
-// globals
-var gs_url, ncwms_url, tilecache_url;
-
 function init_prism_map() {
     var selectionLayer, options, mapControls, selLayerName, panelControls,
         map, defaults, params, datalayerName, cb;

--- a/pdp/static/js/vic_gen1_app.js
+++ b/pdp/static/js/vic_gen1_app.js
@@ -36,7 +36,7 @@ $(document).ready(function () {
             }
         });
     });
-    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
 
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
 

--- a/pdp/static/js/vic_gen1_app.js
+++ b/pdp/static/js/vic_gen1_app.js
@@ -27,9 +27,18 @@ $(document).ready(function () {
             dlLink.onExtensionChange($(this).val());
         }
     );
-    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
-    ncwmsLayer.events.register('change', dlLink, dlLink.onBoxChange);
+
+    ncwmsLayer.events.register('change', dlLink, function () {
+        getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
+            if (selectionLayer.features.length > 0) {
+                dlLink.onBoxChange({feature: selectionLayer.features[0]});
+            }
+        });
+    });
+    ncwmsLayer.events.registerPriority('change', dlLink, dlLink.onLayerChange);
+
     selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
+
     dlLink.register($('#download-timeseries'), function (node) {
         node.attr('href', dlLink.getUrl());
     }

--- a/pdp/static/js/vic_gen1_app.js
+++ b/pdp/static/js/vic_gen1_app.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, getCatalog, init_vic_map, processNcwmsLayerMetadata, getVICControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
+/*global $, jQuery, OpenLayers, pdp, init_vic_map, processNcwmsLayerMetadata, getVICControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
 
 "use strict";
 
@@ -7,7 +7,7 @@
 var catalog;
 
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer,
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request,
         dlLink, mdLink;
 
     map = init_vic_map();
@@ -16,6 +16,9 @@ $(document).ready(function () {
 
     ncwmsLayer = map.getClimateLayer();
     selectionLayer = map.getSelectionLayer();
+
+    catalogUrl = "../catalog/catalog.json";
+    catalog_request = $.ajax(catalogUrl, {dataType: "json"});
 
     document.getElementById("pdp-controls").appendChild(getVICControls(pdp.ensemble_name));
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
@@ -62,7 +65,7 @@ $(document).ready(function () {
         }
     );
 
-    getCatalog(function (data) {
+    catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
         processNcwmsLayerMetadata(ncwmsLayer);
         // Set the data URL as soon as it is available

--- a/pdp/static/js/vic_gen1_app.js
+++ b/pdp/static/js/vic_gen1_app.js
@@ -3,11 +3,8 @@
 
 "use strict";
 
-// globals
-var catalog;
-
 $(document).ready(function () {
-    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request,
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog,
         dlLink, mdLink;
 
     map = init_vic_map();
@@ -32,6 +29,7 @@ $(document).ready(function () {
     );
 
     ncwmsLayer.events.register('change', dlLink, function () {
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
             if (selectionLayer.features.length > 0) {
                 dlLink.onBoxChange({feature: selectionLayer.features[0]});
@@ -67,7 +65,7 @@ $(document).ready(function () {
 
     catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
-        processNcwmsLayerMetadata(ncwmsLayer);
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
         // Set the data URL as soon as it is available
         dlLink.onLayerChange();
         mdLink.onLayerChange();

--- a/pdp/static/js/vic_gen1_app.js
+++ b/pdp/static/js/vic_gen1_app.js
@@ -5,7 +5,7 @@
 
 $(document).ready(function () {
     var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog,
-        dlLink, mdLink;
+        dlLink, mdLink, capabilities_request, ncwms_capabilities;
 
     map = init_vic_map();
     loginButton = pdp.init_login('login-div');
@@ -16,6 +16,8 @@ $(document).ready(function () {
 
     catalogUrl = "../catalog/catalog.json";
     catalog_request = $.ajax(catalogUrl, {dataType: "json"});
+
+    capabilities_request = getNCWMSLayerCapabilities(ncwmsLayer);
 
     document.getElementById("pdp-controls").appendChild(getVICControls(pdp.ensemble_name));
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
@@ -30,15 +32,22 @@ $(document).ready(function () {
 
     ncwmsLayer.events.register('change', dlLink, function () {
         processNcwmsLayerMetadata(ncwmsLayer, catalog);
-        getNCWMSLayerCapabilities(ncwmsLayer).done(function() {
+        capabilities_request = getNCWMSLayerCapabilities(ncwmsLayer);
+        capabilities_request.done(function(data) {
+            ncwms_capabilities = data;
             if (selectionLayer.features.length > 0) {
-                dlLink.onBoxChange({feature: selectionLayer.features[0]});
+                dlLink.onBoxChange({feature: selectionLayer.features[0]}, ncwms_capabilities);
             }
         });
     });
     ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
 
-    selectionLayer.events.register('featureadded', dlLink, dlLink.onBoxChange);
+    selectionLayer.events.register('featureadded', dlLink, function (selection){
+        capabilities_request.done(function(data) {
+            ncwms_capabilities = data;
+            dlLink.onBoxChange(selection, data);
+        });
+    });
 
     dlLink.register($('#download-timeseries'), function (node) {
         node.attr('href', dlLink.getUrl());
@@ -63,6 +72,9 @@ $(document).ready(function () {
         }
     );
 
+    capabilities_request.done(function (data) {
+        ncwms_capabilities = data;
+    });
     catalog_request.done(function (data) {
         catalog = dlLink.catalog = mdLink.catalog = data;
         processNcwmsLayerMetadata(ncwmsLayer, catalog);

--- a/pdp/static/js/vic_gen1_controls.js
+++ b/pdp/static/js/vic_gen1_controls.js
@@ -4,7 +4,7 @@
 "use strict";
 
 // globals
-var catalog, current_dataset;
+var catalog;
 
 function getVICControls(ensemble_name) {
     var div, form, fieldset, varMapping;

--- a/pdp/static/js/vic_gen1_controls.js
+++ b/pdp/static/js/vic_gen1_controls.js
@@ -3,9 +3,6 @@
 
 "use strict";
 
-// globals
-var catalog;
-
 function getVICControls(ensemble_name) {
     var div, form, fieldset, varMapping;
 

--- a/pdp/static/js/vic_gen1_map.js
+++ b/pdp/static/js/vic_gen1_map.js
@@ -5,7 +5,7 @@
 
 function init_vic_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
-        defaults, map, params, datalayerName, ncwms, cb;
+        defaults, map, params, datalayerName, cb;
 
     // Map Config
     options = BC3005_map_options();
@@ -36,7 +36,7 @@ function init_vic_map() {
     };
 
     datalayerName = "Climate raster";
-    ncwms =  new OpenLayers.Layer.WMS(
+    var ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         params,

--- a/pdp/static/js/vic_gen1_map.js
+++ b/pdp/static/js/vic_gen1_map.js
@@ -3,9 +3,6 @@
 
 "use strict";
 
-// globals
-var current_dataset;
-
 function init_vic_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
         defaults, map, params, datalayerName, ncwms, cb;
@@ -54,7 +51,6 @@ function init_vic_map() {
     );
 
     getNCWMSLayerCapabilities(ncwms); // async save into global var ncwmsCapabilities
-    current_dataset = params.layers;
 
     map.addLayers(
         [

--- a/pdp/static/js/vic_gen1_map.js
+++ b/pdp/static/js/vic_gen1_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, Colorbar, BC3005_map_options_vic, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getBC3005Bounds_vic, getNCWMSLayerCapabilities, getBC3005OsmBaseLayer, getOpacitySlider*/
+/*global $, jQuery, OpenLayers, pdp, Colorbar, BC3005_map_options_vic, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getBC3005Bounds_vic, getBC3005OsmBaseLayer, getOpacitySlider*/
 
 "use strict";
 
@@ -49,8 +49,6 @@ function init_vic_map() {
             tileSize: new OpenLayers.Size(512, 512)
         }
     );
-
-    getNCWMSLayerCapabilities(ncwms); // async save into global var ncwmsCapabilities
 
     map.addLayers(
         [

--- a/pdp/static/js/vic_gen1_map.js
+++ b/pdp/static/js/vic_gen1_map.js
@@ -1,11 +1,11 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, Colorbar, BC3005_map_options_vic, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getBC3005Bounds_vic, getBC3005OsmBaseLayer, getOpacitySlider*/
+/*global $, jQuery, OpenLayers, pdp, Colorbar, BC3005_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getBC3005Bounds_vic, getBC3005OsmBaseLayer, getOpacitySlider*/
 
 "use strict";
 
 function init_vic_map() {
     var options, mapControls, selLayerName, selectionLayer, panelControls,
-        defaults, map, params, datalayerName, cb;
+        defaults, map, params, datalayerName, cb, ncwms;
 
     // Map Config
     options = BC3005_map_options();
@@ -36,7 +36,7 @@ function init_vic_map() {
     };
 
     datalayerName = "Climate raster";
-    var ncwms =  new OpenLayers.Layer.WMS(
+    ncwms =  new OpenLayers.Layer.WMS(
         datalayerName,
         pdp.ncwms_url,
         params,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def recursive_list(pkg_dir, basedir):
     return [ x for x in find() ]
 
 
-__version__ = '2.3.3'
+__version__ = '2.3.4'
 
 setup(
     name="pdp",


### PR DESCRIPTION
Overview

* ncWMS layer capabilities now refreshed on layer change event
* `catalog` removed from global scope
* removed various unused global vars: `current_dataset`, `ensemble_name`, `gs_url`, `tilecache_url`, `map`, `pcds_map`
* Unified `catalog` request method between portals
* Unified `ncwms` declaration in global scope