### PR TITLE
Ensure that the datepicker dates remain consistent with the trange

### DIFF
--- a/pdp/static/js/pdp_raster_map.js
+++ b/pdp/static/js/pdp_raster_map.js
@@ -135,19 +135,29 @@ function processNcwmsLayerMetadata(ncwms_layer, catalog) {
     });
 }
 
-
 function setTimeAvailable(begin, end) {
     //TODO: only present times available in ncwms capabilities for this layer
     var yearRange = begin.getFullYear().toString(10) + ":" + end.getFullYear().toString(10);
+    var prevMinDate = $(".datepickerstart").datepicker("option", "minDate");
+    var prevMaxDate = $(".datepickerend").datepicker("option", "maxDate");
+    var fromDate = $(".datepickerstart").datepicker("getDate");
+    var toDate = $(".datepickerend").datepicker("getDate");
 
     $.each([".datepickerstart", ".datepickerend"], function (idx, val) {
         $(val).datepicker("option", "minDate", begin);
         $(val).datepicker("option", "maxDate", end);
         $(val).datepicker("option", "yearRange", yearRange);
     });
-    $(".datepicker").datepicker("setDate", begin);
-    $(".datepickerstart").datepicker("setDate", begin);
-    $(".datepickerend").datepicker("setDate", end);
+
+    // Only update the dates if they haven't been changed
+    // (null indicates initial page load)
+    if (prevMinDate === null || fromDate.getTime() === prevMinDate.getTime()) {
+        //$(".datepicker").datepicker("setDate", begin);
+        $(".datepickerstart").datepicker("setDate", begin);
+    }
+    if (prevMaxDate === null || toDate.getTime() === prevMaxDate.getTime()) {
+        $(".datepickerend").datepicker("setDate", end);
+    }
 }
 
 function intersection(b1, b2) {


### PR DESCRIPTION
Fixes #59. Introduces a simple check to determine if the datepicker start/end dates have been changed from the possible min/max values for the current dataset (default behaviour is to set the displayed dates to the full time range). If either of the dates have been changed, the new value will stay persistent when a new dataset is selected. This ensures that the min/max dates will still be set dynamically according to the ncwms data but the range displayed remains consistent with the `trange` set for the download link.

[Demo](http://docker2.pcic.uvic.ca:8082/hydro_model_out/map/)