### PR TITLE
Add Gridded Observations portal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
       - libgdal-dev
       - libhdf5-serial-dev
       - libnetcdf-dev
+  addons:
+    postgresql: "9.4"
 env:
   global:
       - GDALVERSION="1.10.1"

--- a/doc/source/pdp.rst
+++ b/doc/source/pdp.rst
@@ -31,3 +31,6 @@ The pdp module
 
 .. automodule:: pdp.portals.vic_gen1
    :members:
+
+.. automodule:: pdp.portals.gridded_observations
+   :members:

--- a/pdp/main.py
+++ b/pdp/main.py
@@ -40,6 +40,10 @@ import portals.vic_gen1 as vic_gen1
 from portals.vic_gen1 import portal as vic_gen1_portal
 from portals.vic_gen1 import data_server as vic_gen1_data_server
 
+import portals.gridded_observations as gridded_observations
+from portals.gridded_observations import portal as gridded_observations_portal
+from portals.gridded_observations import data_server as gridded_observations_data_server
+
 #global_config = get_config()
 #dsn = global_config['dsn']
 #pcds_dsn = global_config['pcds_dsn']
@@ -61,6 +65,7 @@ def initialize_frontend(global_config, use_auth=False, use_analytics=False):
         ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_portal(global_config)),
         ('^/{}/.*$'.format(bc_prism.url_base), bc_prism_portal(global_config)),
         ('^/{}/.*$'.format(vic_gen1.url_base), vic_gen1_portal(global_config)),
+        ('^/{}/.*$'.format(gridded_observations.url_base), gridded_observations_portal(global_config)),
         ('^/{}/.*$'.format(bcsd_canada.url_base), bcsd_canada_portal(global_config)),
         ('^/{}/.*$'.format(bccaq_extremes.url_base), bccaq_extremes_portal(global_config)),
         ('^/docs/.*$', docs_app),
@@ -81,6 +86,7 @@ def initialize_backend(global_config, use_auth=False, use_analytics=False):
         ('^/{}/.*$'.format(bc_prism.url_base), bc_prism_data_server(global_config, bc_prism.ensemble_name)),
         ('^/{}/.*$'.format(bcsd_canada.url_base), bcsd_canada_data_server(global_config, bcsd_canada.ensemble_name)),
         ('^/{}/.*$'.format(vic_gen1.url_base), vic_gen1_data_server(global_config, vic_gen1.ensemble_name)),
+        ('^/{}/.*$'.format(gridded_observations.url_base), gridded_observations_data_server(global_config, gridded_observations.ensemble_name)),
         ('^/{}/.*$'.format(bccaq_extremes.url_base), bccaq_extremes_data_server(global_config, bccaq_extremes.ensemble_name)),
         ('^/{}/.*$'.format(hydro_stn.url_base), hydro_stn_data_server(global_config)),
         ('^/{}/.*$'.format(pcds.url_base), pcds_data_server(global_config))

--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -1,0 +1,60 @@
+'''The pdp.portals.gridded_observations module configures a raster portal
+ which serves gridded climate data used by the VIC model.'''
+
+from pdp import wrap_auth
+from pdp.dispatch import PathDispatcher
+from pdp_util.map import MapApp
+from pdp_util.raster import RasterServer, RasterCatalog, RasterMetadata
+from pdp_util.ensemble_members import EnsembleMemberLister
+
+from pdp.minify import wrap_mini
+from pdp.portals import updateConfig, raster_conf
+
+ensemble_name = 'gridded-obs-met-data'
+url_base = 'gridded_observations'
+
+class GriddedObservationsEnsembleLister(EnsembleMemberLister):
+
+    def list_stuff(self, ensemble):
+        dataset_names = {
+            "ANUSPLIN_CDA_v2012.1": "ANUSPLIN",
+            "SYMAP_BC_v1": "VIC FORCINGS",
+            "TPS_NWNA_v1": "TPS"}
+        for dfv in ensemble.data_file_variables:
+            yield dataset_names[dfv.file.run.model.short_name], dfv.netcdf_variable_name, dfv.file.unique_id.replace('+', '-')
+
+def data_server(config, ensemble_name):
+    dsn = config['dsn']
+    conf = raster_conf(dsn, config, ensemble_name, url_base)
+    data_server = wrap_auth(RasterServer(dsn, conf))
+    return data_server
+
+def portal(config):
+    dsn = config['dsn']
+    portal_config = {
+        'title': 'Gridded Climate Observations',
+        'ensemble_name': ensemble_name,
+        'js_files' : 
+            wrap_mini([
+                'js/gridded_observations_map.js',
+                'js/gridded_observations_controls.js',
+                'js/gridded_observations_app.js'],
+                basename=url_base, debug=(not config['js_min']))
+    }
+
+    portal_config = updateConfig(config, portal_config)
+    map_app = wrap_auth(MapApp(**portal_config), required=False)
+
+    conf = raster_conf(dsn, config, ensemble_name, url_base)
+    catalog_server = RasterCatalog(dsn, conf) #No Auth
+
+    menu = GriddedObservationsEnsembleLister(dsn)
+
+    metadata = RasterMetadata(dsn)
+
+    return PathDispatcher([
+        ('^/map/?.*$', map_app),
+        ('^/catalog/.*$', catalog_server),
+        ('^/menu.json.*$', menu),
+        ('^/metadata.json.*$', metadata),
+    ])

--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -20,7 +20,8 @@ class GriddedObservationsEnsembleLister(EnsembleMemberLister):
             "ANUSPLIN_CDA_v2012.1": "ANUSPLIN",
             "SYMAP_BC_v1": "VIC FORCINGS",
             "TPS_NWNA_v1": "TPS"}
-        for dfv in ensemble.data_file_variables:
+
+        for dfv in sorted(ensemble.data_file_variables, key=lambda dfv: dfv.netcdf_variable_name):
             yield dataset_names[dfv.file.run.model.short_name], dfv.netcdf_variable_name, dfv.file.unique_id.replace('+', '-')
 
 def data_server(config, ensemble_name):
@@ -32,7 +33,7 @@ def data_server(config, ensemble_name):
 def portal(config):
     dsn = config['dsn']
     portal_config = {
-        'title': 'Gridded Climate Observations',
+        'title': 'Gridded Daily Meteorological Databases',
         'ensemble_name': ensemble_name,
         'js_files' : 
             wrap_mini([

--- a/pdp/static/js/gridded_observations_app.js
+++ b/pdp/static/js/gridded_observations_app.js
@@ -23,7 +23,7 @@ $(document).ready(function () {
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
 
     // Data Download Link
-    dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'sm', '0:54787', '0:163', '0:215');
+    dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'sm', '', '', '');
     $('#data-format-selector').change(
         function (evt) {
             dlLink.onExtensionChange($(this).val());

--- a/pdp/static/js/gridded_observations_app.js
+++ b/pdp/static/js/gridded_observations_app.js
@@ -1,0 +1,85 @@
+/*jslint browser: true, devel: true */
+/*global $, jQuery, OpenLayers, pdp, init_obs_map, processNcwmsLayerMetadata, getObsControls, getRasterDownloadOptions, RasterDownloadLink, MetadataDownloadLink*/
+
+"use strict";
+
+$(document).ready(function () {
+    var map, loginButton, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog,
+        dlLink, mdLink, capabilities_request, ncwms_capabilities;
+
+    map = init_obs_map();
+    loginButton = pdp.init_login('login-div');
+    pdp.checkLogin(loginButton);
+
+    ncwmsLayer = map.getClimateLayer();
+    selectionLayer = map.getSelectionLayer();
+
+    catalogUrl = "../catalog/catalog.json";
+    catalog_request = $.ajax(catalogUrl, {dataType: "json"});
+
+    capabilities_request = getNCWMSLayerCapabilities(ncwmsLayer);
+
+    document.getElementById("pdp-controls").appendChild(getObsControls(pdp.ensemble_name));
+    document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
+
+    // Data Download Link
+    dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'sm', '0:54787', '0:163', '0:215');
+    $('#data-format-selector').change(
+        function (evt) {
+            dlLink.onExtensionChange($(this).val());
+        }
+    );
+
+    ncwmsLayer.events.register('change', dlLink, function () {
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
+        capabilities_request = getNCWMSLayerCapabilities(ncwmsLayer);
+        capabilities_request.done(function(data) {
+            ncwms_capabilities = data;
+            if (selectionLayer.features.length > 0) {
+                dlLink.onBoxChange({feature: selectionLayer.features[0]}, ncwms_capabilities);
+            }
+        });
+    });
+    ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
+
+    selectionLayer.events.register('featureadded', dlLink, function (selection){
+        capabilities_request.done(function(data) {
+            ncwms_capabilities = data;
+            dlLink.onBoxChange(selection, data);
+        });
+    });
+
+    dlLink.register($('#download-timeseries'), function (node) {
+        node.attr('href', dlLink.getUrl());
+    }
+                   );
+    dlLink.trigger();
+    $('#download-timeseries').click(loginButton, pdp.checkAuthBeforeDownload);
+
+    // Metadata/Attributes Download Link
+    mdLink = new MetadataDownloadLink($('#download-metadata'), ncwmsLayer, undefined);
+    ncwmsLayer.events.register('change', mdLink, mdLink.onLayerChange);
+    mdLink.register($('#download-metadata'), function (node) {
+        node.attr('href', mdLink.getUrl());
+    }
+                   );
+    mdLink.trigger();
+
+    // Date picker event for both links
+    $("[class^='datepicker']").change(
+        function (evt) {
+            dlLink.onTimeChange();
+        }
+    );
+
+    capabilities_request.done(function (data) {
+        ncwms_capabilities = data;
+    });
+    catalog_request.done(function (data) {
+        catalog = dlLink.catalog = mdLink.catalog = data;
+        processNcwmsLayerMetadata(ncwmsLayer, catalog);
+        // Set the data URL as soon as it is available
+        dlLink.onLayerChange();
+        mdLink.onLayerChange();
+    });
+});

--- a/pdp/static/js/gridded_observations_controls.js
+++ b/pdp/static/js/gridded_observations_controls.js
@@ -1,0 +1,22 @@
+/*jslint browser: true, devel: true */
+/*global $, jQuery, OpenLayers, pdp, getRasterAccordionMenu, getTimeSelected, ncwmsCapabilities, getRasterNativeProj, getRasterBbox, rasterBBoxToIndicies, intersection*/
+
+"use strict";
+
+function getObsControls(ensemble_name) {
+    var div, form, fieldset, varMapping;
+
+    div = pdp.createDiv('', 'control');
+    form = pdp.createForm(undefined, undefined, undefined);
+    fieldset = pdp.createFieldset("filterset", "Dataset Selection");
+    varMapping = {
+        'tasmax': 'Maximum Temperature',
+        'tasmin': 'Minimum Temperature',
+        'pr': 'Precipitation',
+        'wind': 'Wind',
+         };
+    fieldset.appendChild(getRasterAccordionMenu(ensemble_name, varMapping));
+    form.appendChild(fieldset);
+    div.appendChild(form);
+    return div;
+}

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -1,0 +1,104 @@
+/*jslint browser: true, devel: true */
+/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getNaBaseLayer, getOpacitySlider*/
+
+"use strict";
+
+function init_obs_map() {
+    var options, mapControls, selLayerName, selectionLayer, panelControls,
+        defaults, map, params, datalayerName, cb, ncwms;
+
+    // Map Config
+    options = na4326_map_options();
+    options.tileManager = null;
+
+    // Map Controls
+    mapControls = getBasicControls();
+    selLayerName = "Box Selection";
+    selectionLayer = getBoxLayer(selLayerName);
+    panelControls = getEditingToolbar([getHandNav(), getBoxEditor(selectionLayer), getPointEditor(selectionLayer)]);
+    mapControls.push(panelControls);
+
+    options.controls = mapControls;
+    map = new OpenLayers.Map('pdp-map', options);
+
+    defaults = {
+        dataset: "wind_day_TPS_NWNA_v1_historical_19450101-20121231",
+        variable: "wind"
+    };
+
+    params = {
+        layers: defaults.dataset + "/" + defaults.variable,
+        transparent: 'true',
+        numcolorbands: 254,
+        version: '1.1.1',
+        srs: "EPSG:4326",
+        TIME: '2000-01-01T00:00:00Z'
+    };
+
+    datalayerName = "Climate raster";
+    ncwms =  new OpenLayers.Layer.WMS(
+        datalayerName,
+        pdp.ncwms_url,
+        params,
+        {
+            maxExtent: getNA4326Bounds(),
+            buffer: 1,
+            ratio: 1.5,
+            opacity: 0.7,
+            transitionEffect: null,
+            tileSize: new OpenLayers.Size(512, 512)
+        }
+    );
+
+    map.addLayers(
+        [
+            ncwms,
+            selectionLayer,
+            getNaBaseLayer(pdp.tilecache_url, 'North America OpenStreetMap', 'world_4326_osm')
+        ]
+    );
+
+    document.getElementById("pdp-map").appendChild(getOpacitySlider(ncwms));
+    map.zoomToExtent(getNA4326Bounds(), true);
+
+    map.getClimateLayer = function () {
+        return map.getLayersByName(datalayerName)[0];
+    };
+    map.getSelectionLayer = function () {
+        return map.getLayersByName(selLayerName)[0];
+    };
+
+    cb = new Colorbar("pdpColorbar", ncwms);
+    cb.refresh_values();
+
+    function set_map_title(layer_name) {
+        $('#map-title').html(layer_name);
+        return true;
+    }
+    ncwms.events.register('change', ncwms, set_map_title);
+
+    ncwms.events.registerPriority('change', ncwms, function (layer_id) {
+        var lyr_params, metadata_req;
+        lyr_params = {
+            "id": layer_id.split('/')[0],
+            "var": layer_id.split('/')[1]
+        };
+        metadata_req = $.ajax({
+            url: "../metadata.json?request=GetMinMaxWithUnits",
+            data: lyr_params
+        });
+        metadata_req.done(function (data) {
+            ncwms.redraw(); // this does a layer redraw
+            cb.force_update(data.min, data.max, data.units); // must be called AFTER ncwms params updated
+        });
+    });
+
+    ncwms.events.triggerEvent('change', defaults.dataset + "/" + defaults.variable);
+
+    // Expose ncwms as a global
+    (function (globals) {
+        globals.ncwms = ncwms;
+    }(window));
+
+    return map;
+}

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -20,6 +20,10 @@ function getBC3005Bounds_vic() {
     return new OpenLayers.Bounds(611014.125, 251336.4375, 2070975.0625, 1737664.5625);
 }
 
+function getBC3005Bounds_obs() {
+    return new OpenLayers.Bounds(611014.125, 251336.4375, 2070975.0625, 1737664.5625);
+}
+
 function getNA4326Bounds() {
     return new OpenLayers.Bounds(-150, 40, -50, 90);
 }
@@ -52,6 +56,17 @@ function BC3005_map_options_vic() {
             units: 'Meter'
         };
     return options;
+}
+
+function BC3005_map_options_obs() {
+  var bounds = getBC3005Bounds_obs,
+      options =  {
+          restrictedExtent: bounds,
+          displayProjection: getProjection(4326),
+          projection: getProjection(3005),
+          units: 'Meter'
+  };
+  return options;
 }
 
 function na4326_map_options() {

--- a/pdp/static/js/vic_gen1_app.js
+++ b/pdp/static/js/vic_gen1_app.js
@@ -23,7 +23,7 @@ $(document).ready(function () {
     document.getElementById("pdp-controls").appendChild(getRasterDownloadOptions(true));
 
     // Data Download Link
-    dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'sm', '0:54787', '0:163', '0:215');
+    dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'sm', '', '', '');
     $('#data-format-selector').change(
         function (evt) {
             dlLink.onExtensionChange($(this).val());

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ numpy  # Allow pip or system install for travis
 openid2rp==1.12
 pdp-util==0.2.4
 ply==3.4
-psycopg2==2.6
+psycopg2==2.7
 pydap-pdp==3.2.4
 pydap.handlers.csv==0.3
 pydap.handlers.pcic==0.0.8


### PR DESCRIPTION
Add a new portal for gridded observational / historical data. ~~This portal requires the user to designate an area for download using the map, which is an end-run around issue #37 . To get the entire spatial domain, you'd draw a rectangle around the whole thing.~~

[Docker for the new portal](http://docker-dev01.pcic.uvic.ca:30032/gridded_observations/map/)

