### PR TITLE
Extend map layer to include entire PNWNAmet dataset

### DIFF
--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -25,7 +25,7 @@ function getBC3005Bounds_obs() {
 }
 
 function getNA4326Bounds() {
-    return new OpenLayers.Bounds(-150, 40, -50, 90);
+    return new OpenLayers.Bounds(-170, 40, -50, 90);
 }
 
 function getWorld4326Bounds() {


### PR DESCRIPTION
![largerarea](https://user-images.githubusercontent.com/4512605/40447759-7b3724a8-5e88-11e8-8ee5-6d0b2cd8cbb0.png)
Extends the map and layer bounds to longitude -170 to display the PNWNAmet dataset, which goes from -168.96875 to -101.03125.