### PR TITLE
Use separate DATA_ROOT and APP_ROOT 

### DIFF
--- a/pdp/static/js/bccaq_extremes_app.js
+++ b/pdp/static/js/bccaq_extremes_app.js
@@ -72,12 +72,12 @@ $(document).ready(function () {
 
     function getTimeIndex(layer_name) {
         var layerUrl = catalog[layer_name.split('/')[0]];
-        var reg = /.*\/data\/(.*?)\/.*/g;
-        var m = reg.exec(layerUrl);
-        layerUrl = layerUrl.replace("data/" + m[1], m[1] + "/catalog")
+        const reg = new RegExp(pdp.data_root + '/(.*)/(.*)');
+        const matches = reg.exec(layerUrl);
+        layerUrl = pdp.app_root + "/" + matches[1] + "/catalog/" + matches[2];
 
         var maxTimeReq = $.ajax({
-                url: (layerUrl + ".dds?time").replace("/data/", "/catalog/")
+                url: layerUrl + ".dds?time"
             });
         $.when(maxTimeReq).done(function (maxTime, unitsSince) {
             var maxTimeIndex = ddsToTimeIndex(maxTime);

--- a/pdp/static/js/bccaq_extremes_map.js
+++ b/pdp/static/js/bccaq_extremes_map.js
@@ -111,7 +111,7 @@ function init_raster_map() {
     na_osm = getNaBaseLayer(pdp.tilecache_url, 'North America OpenStreetMap', 'world_4326_osm', mapControls.projection);
 
     defaults = {
-        dataset: "rx1dayETCCDI_yr_BCCAQ-ANUSPLIN300-CanESM2_historical-rcp26_r1i1p1_1950-2100",
+        dataset: "rx1dayETCCDI_yr_BCCAQ-ANUSPLIN300-MRI-CGCM3_historical-rcp85_r1i1p1_1950-2100",
         variable: "rx1dayETCCDI"
     };
 

--- a/pdp/static/js/crmp_app.js
+++ b/pdp/static/js/crmp_app.js
@@ -14,7 +14,8 @@ $(document).ready(function () {
 
     filtChange = pdp.curry(CRMPFilterChange, map);
 
-    downloadForm = pdp.createForm("download-form", "download-form", "get", "../../data/pcds/agg/");
+    const dataUrl = pdp.data_root + "/pcds/agg/";
+    downloadForm = pdp.createForm("download-form", "download-form", "get", dataUrl);
     document.getElementById("pdp-controls").appendChild(downloadForm);
 
     downloadForm.appendChild(getCRMPControls(map));

--- a/pdp/static/js/hydro_stn_app.js
+++ b/pdp/static/js/hydro_stn_app.js
@@ -53,7 +53,7 @@ $(document).ready(function () {
 
             row.idx = idx;
             parser = document.createElement('a');
-            parser.href = "../../data/hydro_stn/" + row.FileName;
+            parser.href = pdp.data_root + "/hydro_stn/" + row.FileName;
             row.url = parser.href;
             pt = new OpenLayers.Geometry.Point(
                 parseFloat(row.Longitude),

--- a/pdp/static/js/hydro_stn_controls.js
+++ b/pdp/static/js/hydro_stn_controls.js
@@ -87,7 +87,7 @@ function addToSidebar(idx, dataArray, loginButton) {
     });
 
     link = document.createElement('a');
-    link.href = "../../data/hydro_stn/" + dataArray[idx].FileName + '.ascii';
+    link.href = pdp.data_root + "/hydro_stn/" + dataArray[idx].FileName + '.ascii';
     link.appendChild(document.createTextNode(dataArray[idx].StationName));
     $(link).click(loginButton, pdp.checkAuthBeforeDownload);
     item.appendChild(link);

--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -427,10 +427,10 @@ MetadataDownloadLink.prototype = {
         dst = lyr_id.split('/')[0];
         this.varname = lyr_id.split('/')[1];
         url = this.catalog[dst];
-        reg = /.*\/data\/(.*?)\/.*/g;
+        reg = new RegExp(pdp.data_root + '/(.*)/(.*)');
         matches = reg.exec(url);
-        url = url.replace("data/" + matches[1], matches[1] + "/catalog");
-
+        //matches[1] is portal url base, matches[2] is dataset, make catalog URL.
+        url = pdp.app_root + "/" + matches[1] + "/catalog/" + matches[2];
         this.dl_url = url;
         this.trigger();
     }

--- a/pdp/static/js/pdp_raster_map.js
+++ b/pdp/static/js/pdp_raster_map.js
@@ -152,9 +152,10 @@ function processNcwmsLayerMetadata(ncwms_layer, catalog) {
 
     // transform the data_server url into the un-authed catalog based url for metadata
     layerUrl = catalog[getNcwmsLayerId(ncwms_layer)];
-    var reg = /.*\/data\/(.*?)\/.*/g;
-    var m = reg.exec(layerUrl);
-    layerUrl = layerUrl.replace("data/" + m[1], m[1] + "/catalog")
+    const reg = new RegExp(pdp.data_root + '/(.*)/(.*)');
+    const matches = reg.exec(layerUrl);
+    //matches[1] is portal base url, matches[2] is dataset, make catalog url
+    layerUrl = pdp.app_root + "/" + matches[1] + "/catalog/" + matches[2];
 
     // Request time variables
     maxTimeReq = $.ajax({

--- a/pdp/templates/map.html
+++ b/pdp/templates/map.html
@@ -19,6 +19,7 @@
       var pdp = {
         VERSION: '0.1',
         app_root: '${app_root}',
+        data_root: '${data_root}',
         gs_url: '${geoserver_url}',
         ncwms_url: ncwmsUrls,
         tilecache_url: tcUrls,


### PR DESCRIPTION
Gets rid of the places where the pdp frontend derived the data root from the app root or vice versa by adding or removing `/data/ `to the path. Supports separate and flexible data and app root URLs.