### PR TITLE
Resolve #90; add defaults for undefined indices

### DIFF
--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -397,6 +397,10 @@ RasterDownloadLink.prototype = {
         end = $(".datepickerend").datepicker("getDate");
         end = this.layer.times.toIndex(end);
 
+        //if either start or end is undefined, fall back to the full time range
+        start = start === undefined ? 0 : start;
+        end = end === undefined ? "" : end;
+
         this.trange = start + ':' + end;
         this.trigger();
     }


### PR DESCRIPTION
Addresses #90, where the front end at least once has generated download links with time slices of the form `[0:undefined]`. I wasn't able to reproduce the error, but I added a check for it: if the starting or ending value of a time slice is undefined, a default value (0 for start, Null for end) will be substituted.

Should the error recur, instead of generating an invalid link that returns no data, the front end should now generate a link that, at worst, returns more data than the user wanted, since it defaults to the entire time range.