### PR TITLE
Fix broken `docs/` endpoint

### DIFF
--- a/pdp/main.py
+++ b/pdp/main.py
@@ -39,7 +39,7 @@ def initialize_frontend(global_config, use_analytics=False):
     mounts.update({
         '/pcds_map': pcds.mk_frontend(global_config),  # legacy url support
         '/css/': static.Cling(resource_filename('pdp_util', 'data')),
-        '/docs/': docs_app
+        '/docs': docs_app
         })
 
     wsgi_app = DispatcherMiddleware(static_app, mounts)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -31,7 +31,7 @@ def test_static(url):
 
 @pytest.mark.crmpdb
 @pytest.mark.parametrize('url', [
-    '/js/crmp_map.js', '/css/main.css', '/images/banner.png'
+    '/js/crmp_map.js', '/css/main.css', '/images/banner.png', '/docs/'
 ])
 def test_static_full(pcic_data_portal, url):
     req = Request.blank(url)


### PR DESCRIPTION
This PR fixes #102 to ensure that the docs/ endpoint is reachable in a proxied configuration (i.e. our prod configuration).