### PR TITLE
Add calendar classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Instead of mutation, prefer to create a new object containing the new value, rat
 
 ### Calendars
 
-PDP datasets use a variety of different, mutually incompatible calendrical systems. These systems include:
+PDP datasets use a variety of different, mutually incompatible calendar systems. These systems include:
 
 - Standard or Gregorian calendar.
 - 365-day calendar: Like the Gregorian calendar, but without leap years.
@@ -332,10 +332,12 @@ To address this situation, we have defined a module `calendars` containing the f
 
 - Class `Calendar`, which represents the general notion of a calendar, 
 and subclasses `GregorianCalendar`, `Fixed365DayCalendar`, `Fixed360DayCalendar`, which represent specific, 
-different calendar types. In particular:
+different calendar types.
    - Rightly or wrongly, `Calendar`s are used as instances (so far we have only discussed things that could be
-   supplied by a fixed object, or singleton). Each `Calendar`instance has an epoch year, which defines the 
-   epoch or origin date for computations the calendar can perform.
+   equally well be supplied by a fixed object, or singleton). 
+   - Each `Calendar` instance has an epoch year, which defines the epoch or origin date for computations the calendar 
+   can perform. Dates before Jan 1 of the epoch year are not valid. This is stupid, a result of lazy implementation, 
+   but it is true for now. Default epoch year is 1800.
    - `Calendar` has abstract methods `isLeapYear()`,  `daysPerMonth()`, `daysPerYear()` that concrete subclasses 
    define in order to specify different particular calendars.
    - `Calendar` provides a number of service methods for validating datetimes and for computing essential 
@@ -343,13 +345,15 @@ different calendar types. In particular:
    any given calendar system.
    
 Most users of this module will not need to define their own `Calendar` subclasses, nor their own instances of
-`Calendar`s (specifying `epochYear`), since the provided standard instances are designed to meet known use cases
+those subclasses (specifying `epochYear`), since the provided standard instances are designed to meet known use cases
 in PDP. However, the option is there for unforeseen applications.
 
-- The standard (and default) `epochYear` is 1900.
-- `calendars` offers pre-instantiated standard calendars of each type, indexed by the standard CF identifiers
+- The standard (and default) `epochYear` is 1800. 
+- The `calendars` module offers pre-instantiated standard calendars of each type, indexed by the standard CF identifiers
 for each type:
-   - `calendars['gregorian']`
+   - `calendars['standard']`,`calendars['gregorian']`
+   - `calendars['365_day']`, `calendars['noleap']`
+   - `calendars['360_day']`
 
 ### Datetimes (in specific calendars)
 
@@ -366,13 +370,13 @@ calendar. (Note: We [prefer composition over inheritance](https://en.wikipedia.o
 
 ### CF time systems
    
-In CF standards compliant datasets, datetimes are represented by index values in a time system defined by units, 
-start datetime, and calendar. 
+In CF standards compliant datasets, datetimes are represented by index values (values of the time dimension) 
+in a time system defined by units, start datetime, and calendar. 
 
 - Units are fixed intervals of time labelled by terms such as 'day', 'hour', 'minute'. 
-- A start datetime is simply a specification of year, month, day, etc., in a calendrical system specified by calendar.
+- A start datetime is a specification of year, month, day, etc., in a specified calendar system.
 - The calendar is specified an identifier chosen from a fixed CF vocabulary that includes 'standard', 'gregorian', 
-'365_day', and '360_day', with the obvious meanings.
+'365_day', 'noleap', and '360_day', with the obvious meanings.
 - A time index _t_ specifies a time point defined as _t_ time units after the start datetime, in the specified calendar.
 
 The following classes represent time systems and datetimes within such a system:
@@ -442,5 +446,5 @@ const end = cfTimeSystem.lastCfDatetime();
 console.log(end.index);  // -> 99999
 
 const today = cfTimeSystem.todayAsCfDatetime();
-console.log(today.index);  // -> some value around (2019 - 1950) * 360
+console.log(today.index);  // -> some value around (<current year> - 1950) * 360
 ```

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The following classes represent time systems and datetimes within such a system:
   could perhaps be improved.
   
 - Class `CfDatetime`, which [composes](https://en.wikipedia.org/wiki/Composition_over_inheritance) a 
-`CfTimeSystem` and an (integer) index to represent a specific time within a CF time system.
+`CfTimeSystem` and a real-valued index to represent a specific time within a CF time system.
    - Like `CalendarDatetime` (to which it is a parallel), `CfDatetime` offers only conversion methods 
    (e.g., `toISOString()`, `toCalendarDatetime`) and factories (e.g., `fromLooseFormat()`).
    - Like `CalendarDatetime`, this is the class in which time arithmetic methods would be placed, but none are

--- a/README.md
+++ b/README.md
@@ -301,3 +301,146 @@ When upgrading, it's easiest to simply copy the existing config and update the p
 Using `supervisorctl`, you should then be able to `reread` the new config, `update` the old version config (so it stops, picks up new autostart/autorestart=false), and `update` the new version.
 
 If there are any errors, they can be found in the `supervisord_logfile`. Errors starting gunicorn can be found in the `error_logfile`.
+
+## Module `calendars`
+
+### Introductory notes
+
+- In this section, we use the term `class`, a concept which strictly speaking JS doesn't support.
+However, we use JS patterns that emulate class-based code fairly closely; in particular, that emulate
+many of the features of the ES6 `class` syntactic sugar. This is currently done via the utilities provided
+in module `classes`.
+
+- Objects that can be instantiated with these constructors are mutable, but few if any mutation methods are
+provided. This is because mutation makes code hard to reason about 
+(it removes [referential transparency](https://nrinaudo.github.io/scala-best-practices/definitions/referential_transparency.html)).
+Instead of mutation, prefer to create a new object containing the new value, rather than mutating an old object.
+
+### Calendars
+
+PDP datasets use a variety of different, mutually incompatible calendrical systems. These systems include:
+
+- Standard or Gregorian calendar.
+- 365-day calendar: Like the Gregorian calendar, but without leap years.
+- 360-day calendar: Every month in every year has exactly 30 days.
+
+JavaScript directly supports only the Gregorian calendar, via the `Date` object. It is not possible (whilst retaining
+developer sanity, or code maintainability) to handle non-Gregorian calendars using a Gregorian calendar.
+Previous code that attempted to do so contained errors traceable to the incompatibility of different calendar systems.
+
+To address this situation, we have defined a module `calendars` containing the following items:
+
+- Class `Calendar`, which represents the general notion of a calendar, 
+and subclasses `GregorianCalendar`, `Fixed365DayCalendar`, `Fixed360DayCalendar`, which represent specific, 
+different calendar types. In particular:
+   - Rightly or wrongly, `Calendar`s are used as instances (so far we have only discussed things that could be
+   supplied by a fixed object, or singleton). Each `Calendar`instance has an epoch year, which defines the 
+   epoch or origin date for computations the calendar can perform.
+   - `Calendar` has abstract methods `isLeapYear()`,  `daysPerMonth()`, `daysPerYear()` that concrete subclasses 
+   define in order to specify different particular calendars.
+   - `Calendar` provides a number of service methods for validating datetimes and for computing essential 
+   quantities, such as the number of milliseconds since epoch. These are fundamental to datetime computations within
+   any given calendar system.
+   
+Most users of this module will not need to define their own `Calendar` subclasses, nor their own instances of
+`Calendar`s (specifying `epochYear`), since the provided standard instances are designed to meet known use cases
+in PDP. However, the option is there for unforeseen applications.
+
+- The standard (and default) `epochYear` is 1900.
+- `calendars` offers pre-instantiated standard calendars of each type, indexed by the standard CF identifiers
+for each type:
+   - `calendars['gregorian']`
+
+### Datetimes (in specific calendars)
+
+The following classes exploit `Calendar` objects to represent datetimes in specific calendrical systems.
+   
+- Class `SimpleDatetime` that bundles together the `year`, `month`, `day`, etc. components of a datetime, 
+_without reference to any specific calendar_.
+
+- Class `CalendarDatetime` composes a `Calendar` with a `SimpleDatetime`, to represent a datetime in a particular
+calendar. (Note: We [prefer composition over inheritance](https://en.wikipedia.org/wiki/Composition_over_inheritance).)
+   - At the moment, it offers only conversion methods (e.g., `toISOString()`) and factories (e.g., `fromMsSinceEpoch()`).
+   - This would be the class in which to place calendar-aware datetime arithmetic methods (e.g., `addDays()`), 
+   but we have no use for this in present applications so the class lacks such methods.
+
+### CF time systems
+   
+In CF standards compliant datasets, datetimes are represented by index values in a time system defined by units, 
+start datetime, and calendar. 
+
+- Units are fixed intervals of time labelled by terms such as 'day', 'hour', 'minute'. 
+- A start datetime is simply a specification of year, month, day, etc., in a calendrical system specified by calendar.
+- The calendar is specified an identifier chosen from a fixed CF vocabulary that includes 'standard', 'gregorian', 
+'365_day', and '360_day', with the obvious meanings.
+- A time index _t_ specifies a time point defined as _t_ time units after the start datetime, in the specified calendar.
+
+The following classes represent time systems and datetimes within such a system:
+   
+- Class `CfTimeSystem`, which represents a CF time system, as above.
+  - Constructed with arguments `units` and `startDate`; the latter is a `CalendarDatetime`, which carries both
+  the calendar and the datetime. This is one of the places where method signature is hard to remember, and
+  could perhaps be improved.
+  
+- Class `CfDatetime`, which [composes](https://en.wikipedia.org/wiki/Composition_over_inheritance) a 
+`CfTimeSystem` and an (integer) index to represent a specific time within a CF time system.
+   - Like `CalendarDatetime` (to which it is a parallel), `CfDatetime` offers only conversion methods 
+   (e.g., `toISOString()`, `toCalendarDatetime`) and factories (e.g., `fromLooseFormat()`).
+   - Like `CalendarDatetime`, this is the class in which time arithmetic methods would be placed, but none are
+   currently needed, so none exist.
+   
+### Usage
+
+Playing at classes is all very well, till somebody loses their mind. How is this intended to be used?
+
+Here are some code snippets that show the application of these objects. Some make it obvious that it
+would be nicer to have (a) more consistent and/or flexible method signatures, and (b) more helper methods.
+
+#### `CalendarDatetime`: Datetimes in various calendars
+
+```javascript
+// Date in Gregorian calendar.
+const apollo11 = new CalendarDatetime(new GregorianCalendar(), 1969, 7, 20);
+console.log(apollo11.toISOString()); // -> 1969-07-20T00:00:00
+console.log(apollo11.toISOString(true)); // -> 1969-07-20
+
+// Or, using the pre-instantiated Gregorian calendar.
+const apollo11 = new CalendarDatetime(calendars.gregorian, 1969, 7, 20);
+
+// Dates in non-Gregorian calendar
+const endOfCentury = new CalendarDatetime(calendars['365_day'], 2099, 12, 31);
+console.log(endOfCentury.toLooseString()); // -> 2099/12/31 00:00:00
+console.log(endOfCentury.toLooseString(true)); // -> 2099/12/31
+```
+
+#### `CfTimeSystem`: CF time systems
+
+```javascript
+// A CF time system: days since 1950-01-01 in 360-day calendar; maximum time index 99999.
+const sinceDate = new CalendarDatetime(calendars['360_day'], 1950, 1, 1);
+const cfTimeSystem = new CfTimeSystem('days', sinceDate, 99999);
+```
+
+#### `CfDatetime`: CF time points
+
+```javascript
+// A CF datetime in the above time system, specified several different ways.
+const cfDatetime = new CfDatetime(cfTimeSystem, 720);
+const cfDatetime = CfDatetime.fromDatetime(cfTimeSystem, 1952, 1, 1);
+const cfDatetime = CfDatetime.fromLooseFormat(cfTimeSystem, '1952/01/01');
+console.log(cfDatetime.index); // -> 720
+console.log(cfDatetime.toLooseString(true)); // -> 1952/01/01
+```
+
+```javascript
+// Some possibly useful time points in the above time system. 
+// Note these are `CfDatetime`s, not CalendarDatetime`s.
+const start = cfTimeSystem.firstCfDatetime();
+console.log(start.index);  // -> 0
+
+const end = cfTimeSystem.lastCfDatetime();
+console.log(end.index);  // -> 99999
+
+const today = cfTimeSystem.todayAsCfDatetime();
+console.log(today.index);  // -> some value around (2019 - 1950) * 360
+```

--- a/pdp/static/js/__test__/calendars.test.js
+++ b/pdp/static/js/__test__/calendars.test.js
@@ -1,0 +1,877 @@
+var each = require('jest-each').default;
+
+require('./globals-helpers').importGlobals([
+    { module: 'js/condExport', name: 'condExport' },
+    { module: 'js/classes.js', name: 'classes' },
+    { module: 'js/calendars.js', name: 'calendars' },
+], '../..');
+
+var formatDatetimeRaw = calendars.formatDatetimeRaw;
+var formatDatetimeISO8601 = calendars.formatDatetimeISO8601;
+var SimpleDatetime = calendars.SimpleDatetime;
+var Calendar = calendars.Calendar;
+var GregorianCalendar = calendars.GregorianCalendar;
+var Fixed365DayCalendar = calendars.Fixed365DayCalendar;
+var Fixed360DayCalendar = calendars.Fixed360DayCalendar;
+var CalendarFactory = calendars.CalendarFactory;
+var CalendarDatetime = calendars.CalendarDatetime;
+var CfTimeSystem = calendars.CfTimeSystem;
+var CfDatetime = calendars.CfDatetime;
+
+var epochYear = 1900;
+var gregorianCalendar = new GregorianCalendar(epochYear);
+var fixed365DayCalendar = new Fixed365DayCalendar(epochYear);
+var fixed360DayCalendar = new Fixed360DayCalendar(epochYear);
+
+// TODO: Add tests for untested methods. These are all mostly shortcuts and
+// convenience methods.
+
+
+// A true universal, upon which we all can agree.
+var msPerDay = 1000 * 60 * 60 * 24;
+
+function leapDaysSinceEpoch(calendar, year) {
+    // Up and including `year`.
+    // Valid only up to 2099!!!
+    return Math.floor((year - calendar.epochYear) / 4);
+}
+
+
+describe('formatDatetimeRaw', function () {
+    each([
+        [1900, 1, 2, 3, 4, 5, '1900-1-2T3-4-5'],
+        [undefined, 1, 2, 3, 4, 5, 'undefined-1-2T3-4-5'],
+    ]).it('%#',
+        function (year, month, day, hour, minute, second, expected) {
+            expect(formatDatetimeRaw(
+                year, month, day, hour, minute, second
+            )).toBe(expected);
+        });
+});
+
+
+describe('formatDatetimeISO8601', function () {
+    each([
+        [1900, 1, 2, 3, 4, 5, '1900-01-02T03:04:05'],
+        [1900, 11, 12, 13, 14, 15, '1900-11-12T13:14:15'],
+        [undefined, 11, 12, 13, 14, 15, ''],
+        [1900, undefined, 12, 13, 14, 15, '1900'],
+        [1900, 11, undefined, 13, 14, 15, '1900-11'],
+        [1900, 11, 12, undefined, 14, 15, '1900-11-12'],
+        [1900, 11, 12, 13, undefined, 15, '1900-11-12T13'],
+        [1900, 11, 12, 13, 14, undefined, '1900-11-12T13:14'],
+    ]).it('%#',
+        function (year, month, day, hour, minute, second, expected) {
+            expect(formatDatetimeISO8601(
+                year, month, day, hour, minute, second
+            )).toBe(expected);
+        });
+});
+
+
+describe('all classes', function () {
+    each([
+        SimpleDatetime,
+        Calendar,
+        GregorianCalendar,
+        Fixed365DayCalendar,
+        Fixed360DayCalendar,
+        CalendarDatetime,
+        CfTimeSystem,
+        CfDatetime
+    ]).describe('%s', function (Class) {
+        it('cannot be called as a function', function () {
+            expect(function () {
+                Class();
+            }).toThrow();
+        });
+    });
+});
+
+
+describe('SimpleDatetime', function () {
+    it('holds the data', function () {
+        var simpleDatetime = new SimpleDatetime(0, 1, 2, 3, 4, 5)
+        expect(simpleDatetime.year).toBe(0);
+        expect(simpleDatetime.month).toBe(1);
+        expect(simpleDatetime.day).toBe(2);
+        expect(simpleDatetime.hour).toBe(3);
+        expect(simpleDatetime.minute).toBe(4);
+        expect(simpleDatetime.second).toBe(5);
+    });
+
+    it('provides defaults', function () {
+        var simpleDatetime = new SimpleDatetime(999);
+        ['month', 'day'].forEach(function (prop) {
+            expect(simpleDatetime[prop]).toBe(1);
+        });
+        ['hour', 'minute', 'second'].forEach(function (prop) {
+            expect(simpleDatetime[prop]).toBe(0);
+        });
+    });
+
+
+    describe('fromIso8601', function () {
+        each([
+            ['1900-01-02T06:07:08', 1900, 1, 2, 6, 7, 8],
+            ['1900-1-2T6:7:8', 1900, 1, 2, 6, 7, 8],
+            ['1900-01-02', 1900, 1, 2, 0, 0, 0],
+            ['1900-01', 1900, 1, 0, 0, 0, 0],
+            ['1900', 1900, 1, 0, 0, 0, 0],
+        ]).it('parses the valid string %s',
+            function (string, year, month, day, hour, minute, second) {
+            var expected = new SimpleDatetime(year, month, day, hour, minute, second);
+            expect(SimpleDatetime.fromIso8601(string)).toEqual(expected);
+        });
+
+        each([
+            'x',
+            'xxxx',
+            '190',
+            '19000',
+            '1900-x',
+            '1900-01-xx',
+            '1900-01-02Txx',
+        ]).it('returns null for the invalid string %s',
+            function (string) {
+            expect(function() { SimpleDatetime.fromIso8601(string) }).toThrow();
+        });
+    });
+});
+
+
+describe('Calendar', function () {
+    var calendar = new Calendar();
+
+    describe('isValidTime', function () {
+        each([
+            // one undefined
+            [undefined, 1, 2, false],
+            [1, undefined, 2, false],
+            [1, 2, undefined, true],
+
+            // two undefined
+            [undefined, undefined, 1, false],
+            [undefined, 1, undefined, false],
+            [1, undefined, undefined, true],
+
+            // three undefined
+            [undefined, undefined, undefined, true],
+
+            // all defined
+            [0, 0, 0, true],
+            [23, 59, 59, true],
+            [-1, 0, 0, false],
+            [0, -1, 0, false],
+            [0, 0, -1, false],
+            [24, 0, 0, false],
+            [0, 60, 0, false],
+            [0, 0, 60, false],
+        ]).it('%d-%d-%d: %s',
+            function (hour, minute, second, expected) {
+                expect(calendar.isValidTime(hour, minute, second)).toBe(expected);
+            });
+    });
+
+});
+
+
+// TODO: Check datetime validation for each calendar method that needs it
+
+
+describe('GregorianCalendar', function () {
+    var calendar = gregorianCalendar;
+
+    it('describes itself', function () {
+        expect(calendar.type).toBe('standard');
+        expect(calendar.name).toBe('Gregorian');
+    });
+
+    describe('isValidDate', function () {
+        each([
+            [undefined, 1, 1, false],
+            [1900, undefined, 1, false],
+            [1900, 1, undefined, true],
+
+            [1900, -1, 1, false],
+            [1900, 13, 1, false],
+
+            [1900, 1, 1, true],
+            [1900, 1, 31, true],
+            [1900, 1, 32, false],
+            [1900, 2, 1, true],
+            [1900, 2, 2, true],
+            [1900, 2, 28, true],
+            [1900, 2, 29, false],
+
+            [1901, 2, 28, true],
+            [1901, 2, 29, false],
+        ]).it('%d-%d-%d: %s',
+            function (year, month, day, expected) {
+                expect(calendar.isValidDate(year, month, day)).toBe(expected);
+            });
+    });
+
+    describe('validateDatetime', function () {
+        each([
+            [undefined, 1, 1, 1, 1, 1],
+            [1901, 2, 29, 1, 1, 1],
+            [1901, 1, 1, 99, 1, 1],
+        ]).it('',
+            function (year, month, day, hour, minute, second) {
+                expect(
+                    function () {
+                        calendar.validateDatetime(year, month, day, hour, minute, second)
+                    }
+                ).toThrow();
+            });
+    });
+
+    describe('isLeapYear', function () {
+        each([
+            [1600, true],
+            [1700, false],
+            [1800, false],
+            [1900, false],
+            [2000, true],
+            [1901, false],
+            [1902, false],
+            [1903, false],
+            [1904, true],
+            [2001, false],
+            [2002, false],
+            [2003, false],
+            [2004, true],
+        ]).it('correctly determines if %d is a leap year',
+            function (year, expected) {
+                expect(calendar.isLeapYear(year)).toBe(expected);
+            });
+    });
+
+    describe('daysPerYear', function () {
+        each([
+            [1900, 365],
+            [1901, 365],
+            [2000, 366],
+        ]).it('correctly returns the number of days for year %d',
+            function (year, days) {
+                expect(calendar.daysPerYear(year)).toBe(days);
+            });
+    });
+
+    describe('daysPerMonth', function () {
+        each([
+            [1900, 1, 31],
+            [1900, 2, 28],
+            [1900, 3, 31],
+            [1900, 4, 30],
+            [1904, 2, 29],
+            [2000, 2, 29],
+        ]).it('correctly returns the number of days for month %d-%d',
+            function (year, month, days) {
+                expect(calendar.daysPerMonth(year, month)).toBe(days);
+            });
+    });
+
+    describe('msPerUnit', function () {
+        each([
+            ['second', undefined, undefined, 1000],
+            ['day', undefined, undefined, msPerDay],
+            ['month', 1901, 1, 31 * msPerDay],
+            ['month', 1901, 4, 30 * msPerDay],
+            ['month', 1900, 2, 28 * msPerDay],
+            ['month', 1901, 2, 28 * msPerDay],
+            ['month', 1902, 2, 28 * msPerDay],
+            ['month', 1903, 2, 28 * msPerDay],
+            ['month', 1904, 2, 29 * msPerDay],
+            ['year', 1900, undefined, 365 * msPerDay],
+            ['year', 1901, undefined, 365 * msPerDay],
+            ['year', 1902, undefined, 365 * msPerDay],
+            ['year', 1903, undefined, 365 * msPerDay],
+            ['year', 1904, undefined, 366 * msPerDay],
+        ]).it('correctly computes ms per %s for %d-%d',
+            function (unit, year, month, ms) {
+                expect(calendar.msPerUnit(unit, year, month)).toBe(ms);
+            });
+    });
+
+    var dateTimeMsSinceEpoch = [
+        [new SimpleDatetime(1900),
+            0],
+        [new SimpleDatetime(1900, 1, 1, 0, 0, 1),
+            1000],
+        [new SimpleDatetime(1900, 1, 1, 0, 1, 0),
+            1000 * 60],
+        [new SimpleDatetime(1900, 1, 1, 1, 0, 0),
+            1000 * 60 * 60],
+        [new SimpleDatetime(1900, 1, 2),
+            msPerDay],
+        [new SimpleDatetime(1900, 1, 3),
+            msPerDay * 2],
+        [new SimpleDatetime(1900, 1, 31),
+            msPerDay * 30],
+        [new SimpleDatetime(1900, 2, 1),
+            msPerDay * 31],
+        [new SimpleDatetime(1900, 3, 1),
+            msPerDay * (31 + 28)],
+        [new SimpleDatetime(1900, 4, 1),
+            msPerDay * (31 + 28 + 31)],
+        [new SimpleDatetime(1900, 12, 1),
+            msPerDay * (365 - 31)],
+        [new SimpleDatetime(1901, 1, 1),
+            msPerDay * 365],
+        [new SimpleDatetime(1950, 1, 1),
+            msPerDay * (50 * 365 + leapDaysSinceEpoch(calendar, 1949))],
+        [new SimpleDatetime(2000, 1, 1),
+            msPerDay * (100 * 365 + leapDaysSinceEpoch(calendar, 1999))]
+    ];
+
+    describe('msSinceEpoch', function () {
+        each(dateTimeMsSinceEpoch)
+        .it('correctly converts FROM %o TO %d ms since epoch',
+            function (datetime, ms) {
+                expect(calendar.msSinceEpoch(datetime)).toBe(ms);
+            });
+    });
+
+    describe('simpleDatetimeFromMsSinceEpoch', function () {
+        each(dateTimeMsSinceEpoch)
+        .it('correctly converts TO %o FROM %d ms since epoch',
+            function (datetime, ms) {
+                expect(calendar.simpleDatetimeFromMsSinceEpoch(ms)).toEqual(datetime);
+            });
+    });
+});
+
+
+describe('Fixed365DayCalendar', function () {
+    var calendar = fixed365DayCalendar;
+
+    it('describes itself', function () {
+        expect(calendar.type).toBe('365_day');
+        expect(calendar.name).toBe('Fixed 365-day');
+    });
+
+    describe('isValidDate', function () {
+        each([
+            [undefined, 1, 1, false],
+            [1900, undefined, 1, false],
+            [1900, 1, undefined, true],
+
+            [1900, -1, 1, false],
+            [1900, 13, 1, false],
+
+            [1900, 1, 1, true],
+            [1900, 1, 31, true],
+            [1900, 1, 32, false],
+            [1900, 2, 1, true],
+            [1900, 2, 2, true],
+            [1900, 2, 28, true],
+            [1900, 2, 29, false],
+            [1900, 2, 30, false],
+
+            [1901, 2, 28, true],
+            [1901, 2, 29, false],
+        ]).it('%d-%d-%d: %s',
+            function (year, month, day, expected) {
+                expect(calendar.isValidDate(year, month, day)).toBe(expected);
+            });
+    });
+
+    describe('validateDatetime', function () {
+        each([
+            [undefined, 1, 1, 1, 1, 1],
+            [1901, 2, 29, 1, 1, 1],
+            [1901, 1, 1, 99, 1, 1],
+        ]).it('',
+            function (year, month, day, hour, minute, second) {
+                expect(
+                    function () {
+                        calendar.validateDatetime(year, month, day, hour, minute, second)
+                    }
+                ).toThrow();
+            });
+    });
+
+    describe('isLeapYear', function () {
+        each([
+            1900, 1901, 1904, 2000, 2001, 2100
+        ]).it('correctly says %d is not a leap year', function (year) {
+            expect(calendar.isLeapYear(year)).toBe(false);
+        });
+    });
+
+    describe('daysPerYear', function () {
+        each([
+            1900, 1901, 1904, 2000, 2001, 2100
+        ]).it('correctly says there are 365 days in every year',
+            function (year) {
+                expect(calendar.daysPerYear(year)).toBe(365);
+            });
+    });
+
+    describe('daysPerMonth', function () {
+        each([
+            [1900, 1, 31],
+            [1900, 2, 28],
+            [1900, 3, 31],
+            [1900, 4, 30],
+            [2000, 2, 28],
+        ]).it('correctly returns the number of days for month %d-%d',
+            function (year, month, days) {
+                expect(calendar.daysPerMonth(year, month)).toBe(days);
+            });
+    });
+
+    describe('msPerUnit', function () {
+        each([
+            ['second', undefined, undefined, 1000],
+            ['day', undefined, undefined, msPerDay],
+            ['month', 1901, 1, 31 * msPerDay],
+            ['month', 1901, 4, 30 * msPerDay],
+            ['month', 1900, 2, 28 * msPerDay],
+            ['month', 1901, 2, 28 * msPerDay],
+            ['month', 1902, 2, 28 * msPerDay],
+            ['month', 1903, 2, 28 * msPerDay],
+            ['year', 1900, undefined, 365 * msPerDay],
+            ['year', 1901, undefined, 365 * msPerDay],
+            ['year', 1902, undefined, 365 * msPerDay],
+            ['year', 1903, undefined, 365 * msPerDay],
+        ]).it('correctly computes ms per %s for %d-%d',
+            function (unit, year, month, ms) {
+                expect(calendar.msPerUnit(unit, year, month)).toBe(ms);
+            });
+    });
+
+    var dateTimeMsSinceEpoch = [
+        [new SimpleDatetime(1900),
+            0],
+        [new SimpleDatetime(1900, 1, 1, 0, 0, 1),
+            1000],
+        [new SimpleDatetime(1900, 1, 1, 0, 1, 0),
+            1000 * 60],
+        [new SimpleDatetime(1900, 1, 1, 1, 0, 0),
+            1000 * 60 * 60],
+        [new SimpleDatetime(1900, 1, 2),
+            msPerDay],
+        [new SimpleDatetime(1900, 1, 3),
+            msPerDay * 2],
+        [new SimpleDatetime(1900, 1, 31),
+            msPerDay * 30],
+        [new SimpleDatetime(1900, 2, 1),
+            msPerDay * 31],
+        [new SimpleDatetime(1900, 3, 1),
+            msPerDay * (31 + 28)],
+        [new SimpleDatetime(1900, 4, 1),
+            msPerDay * (31 + 28 + 31)],
+        [new SimpleDatetime(1900, 12, 1),
+            msPerDay * (365 - 31)],
+        [new SimpleDatetime(1901, 1, 1),
+            msPerDay * 365],
+        [new SimpleDatetime(1950, 1, 1),
+            msPerDay * (50 * 365)],
+        [new SimpleDatetime(2000, 1, 1),
+            msPerDay * (100 * 365)]
+    ];
+
+    describe('msSinceEpoch', function () {
+        each(dateTimeMsSinceEpoch)
+        .it('correctly converts FROM %o TO %d ms since epoch',
+            function (datetime, ms) {
+                expect(calendar.msSinceEpoch(datetime)).toBe(ms);
+            });
+    });
+
+    describe('simpleDatetimeFromMsSinceEpoch', function () {
+        each(dateTimeMsSinceEpoch)
+        .it('correctly converts TO %o FROM %d ms since epoch',
+            function (datetime, ms) {
+                expect(calendar.simpleDatetimeFromMsSinceEpoch(ms)).toEqual(datetime);
+            });
+    });
+});
+
+
+describe('Fixed360DayCalendar', function () {
+    var calendar = fixed360DayCalendar;
+
+    it('describes itself', function () {
+        expect(calendar.type).toBe('360_day');
+        expect(calendar.name).toBe('Fixed 360-day');
+    });
+
+    describe('isValidDate', function () {
+        each([
+            [undefined, 1, 1, false],
+            [1900, undefined, 1, false],
+            [1900, 1, undefined, true],
+
+            [1900, -1, 1, false],
+            [1900, 13, 1, false],
+
+            [1900, 1, 1, true],
+            [1900, 1, 30, true],
+            [1900, 1, 31, false],
+            [1900, 2, 1, true],
+            [1900, 2, 28, true],
+            [1900, 2, 29, true],
+            [1900, 2, 30, true],
+
+            [1901, 2, 28, true],
+            [1901, 2, 29, true],
+        ]).it('%d-%d-%d: %s',
+            function (year, month, day, expected) {
+                expect(calendar.isValidDate(year, month, day)).toBe(expected);
+            });
+    });
+
+    describe('validateDatetime', function () {
+        each([
+            [undefined, 1, 1, 1, 1, 1],
+            [1901, 2, 33, 1, 1, 1],
+            [1901, 1, 1, 99, 1, 1],
+        ]).it('',
+            function (year, month, day, hour, minute, second) {
+                expect(
+                    function () {
+                        calendar.validateDatetime(year, month, day, hour, minute, second)
+                    }
+                ).toThrow();
+            });
+    });
+
+    describe('isLeapYear', function () {
+        each([
+            1900, 1901, 1904, 2000, 2001, 2100
+        ]).it('correctly says %d is not a leap year', function (year) {
+            expect(calendar.isLeapYear(year)).toBe(false);
+        });
+    });
+
+    describe('daysPerYear', function () {
+        each([
+            1900, 1901, 1904, 2000, 2001, 2100
+        ]).it('correctly says there are 360 days in %d',
+            function (year) {
+                expect(calendar.daysPerYear(year)).toBe(360);
+            });
+    });
+
+    describe('daysPerMonth', function () {
+        each([
+            [1900, 1],
+            [1900, 2],
+            [1900, 3],
+            [1900, 4],
+            [2000, 2],
+        ]).it('correctly returns the number of days for month %d-%d',
+            function (year, month) {
+                expect(calendar.daysPerMonth(year, month)).toBe(30);
+            });
+    });
+
+    describe('msPerUnit', function () {
+        each([
+            ['second', undefined, undefined, 1000],
+            ['day', undefined, undefined, msPerDay],
+            ['month', 1901, 1, 30 * msPerDay],
+            ['month', 1901, 4, 30 * msPerDay],
+            ['month', 1900, 2, 30 * msPerDay],
+            ['month', 1901, 2, 30 * msPerDay],
+            ['month', 1902, 2, 30 * msPerDay],
+            ['month', 1903, 2, 30 * msPerDay],
+            ['year', 1900, undefined, 360 * msPerDay],
+            ['year', 1901, undefined, 360 * msPerDay],
+            ['year', 1902, undefined, 360 * msPerDay],
+            ['year', 1903, undefined, 360 * msPerDay],
+        ]).it('correctly computes ms per %s for %d-%d',
+            function (unit, year, month, ms) {
+                expect(calendar.msPerUnit(unit, year, month)).toBe(ms);
+            });
+    });
+
+    var dateTimeMsSinceEpoch = [
+        [new SimpleDatetime(1900),
+            0],
+        [new SimpleDatetime(1900, 1, 1, 0, 0, 1),
+            1000],
+        [new SimpleDatetime(1900, 1, 1, 0, 1, 0),
+            1000 * 60],
+        [new SimpleDatetime(1900, 1, 1, 1, 0, 0),
+            1000 * 60 * 60],
+        [new SimpleDatetime(1900, 1, 2),
+            msPerDay],
+        [new SimpleDatetime(1900, 1, 3),
+            msPerDay * 2],
+        [new SimpleDatetime(1900, 1, 30),
+            msPerDay * 29],
+        [new SimpleDatetime(1900, 2, 1),
+            msPerDay * 30],
+        [new SimpleDatetime(1900, 3, 1),
+            msPerDay * 30 * 2],
+        [new SimpleDatetime(1900, 4, 1),
+            msPerDay * 30 * 3],
+        [new SimpleDatetime(1900, 12, 1),
+            msPerDay * 30 * 11],
+        [new SimpleDatetime(1901, 1, 1),
+            msPerDay * 360],
+        [new SimpleDatetime(1950, 1, 1),
+            msPerDay * (50 * 360)],
+        [new SimpleDatetime(2000, 1, 1),
+            msPerDay * (100 * 360)]
+    ];
+
+    describe('msSinceEpoch', function () {
+        each(dateTimeMsSinceEpoch)
+        .it('correctly converts FROM %o TO %d ms since epoch',
+            function (datetime, ms) {
+                expect(calendar.msSinceEpoch(datetime)).toBe(ms);
+            });
+    });
+
+    describe('simpleDatetimeFromMsSinceEpoch', function () {
+        each(dateTimeMsSinceEpoch)
+        .it('correctly converts TO %o FROM %d ms since epoch',
+            function (datetime, ms) {
+                expect(calendar.simpleDatetimeFromMsSinceEpoch(ms)).toEqual(datetime);
+            });
+    });
+});
+
+
+describe('CalendarDatetime', function () {
+    describe('toMsSinceEpoch', function () {
+        each([
+            [gregorianCalendar, 1900, 1, 1, 0, 0, 0, 0],
+            [fixed365DayCalendar, 1900, 1, 1, 0, 0, 0, 0],
+            [fixed360DayCalendar, 1900, 1, 1, 0, 0, 0, 0],
+
+            [gregorianCalendar, 1950, 1, 1, 0, 0, 0,
+                msPerDay * (50 * 365 + leapDaysSinceEpoch(gregorianCalendar, 1949))],
+            [fixed365DayCalendar, 1950, 1, 1, 0, 0, 0,
+                msPerDay * (50 * 365)],
+            [fixed360DayCalendar, 1950, 1, 1, 0, 0, 0,
+                msPerDay * (50 * 360)],
+        ]).it('',
+            function (
+                calendar, year, month, day, hour, minute, second, ms
+            ) {
+                var cdt = new CalendarDatetime(
+                    calendar, year, month, day, hour, minute, second
+                );
+                expect(cdt.toMsSinceEpoch()).toBe(ms);
+            });
+    });
+});
+
+
+describe('CalendarFactory', function () {
+    var calendarFactory = new CalendarFactory();
+
+    describe('makeCalendar', function () {
+        function reducedType(type) {
+            if (
+                type === 'standard' ||
+                type === 'gregorian' ||
+                type === 'proleptic_gregorian'
+            ) {
+                return 'standard';
+            }
+            return type;
+        }
+
+        each(CalendarFactory.calendarTypes)
+        .it('%s', function (type) {
+            var calendar = calendarFactory.createCalendar(type);
+            expect(calendar.type).toBe(reducedType(type));
+        });
+    });
+});
+
+
+describe('CfTimeSystem', function () {
+    // Not much to see here.
+    // describe('', function () {
+    //     it('', function () {
+    //
+    //     });
+    // });
+});
+
+
+describe('CfDatetime', function () {
+    function testToCalendarDatetime(
+        index, units, startDate,
+        year, month, day, hour, minute, second) {
+        var cfTimeSystem = new CfTimeSystem(units, startDate);
+        var cfTime = new CfDatetime(cfTimeSystem, index);
+        var expected = new CalendarDatetime(
+            startDate.calendar, year, month, day, hour, minute, second
+        );
+        expect(cfTime.toCalendarDatetime()).toEqual(expected);
+    }
+
+    function testFromDatetime(
+        index, units, startDate,
+        year, month, day, hour, minute, second) {
+        var cfTimeSystem = new CfTimeSystem(units, startDate);
+        var cfTime = CfDatetime.fromDatetime(
+            cfTimeSystem, year, month, day, hour, minute, second
+        );
+        expect(cfTime.index).toEqual(index);
+    }
+
+    describe('for GregorianCalendar', function () {
+        var startDate = new CalendarDatetime(gregorianCalendar, 1950, 1, 1);
+
+        var testCases = [
+            [0, 'seconds', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'seconds', startDate, 1950, 1, 1, 0, 0, 1],
+            [10, 'seconds', startDate, 1950, 1, 1, 0, 0, 10],
+            [100, 'seconds', startDate, 1950, 1, 1, 0, 1, 40],
+            [1000, 'seconds', startDate, 1950, 1, 1, 0, 16, 40],
+            [10000, 'seconds', startDate, 1950, 1, 1, 2, 46, 40],
+            [100000, 'seconds', startDate, 1950, 1, 2, 3, 46, 40],
+
+            [0, 'minutes', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'minutes', startDate, 1950, 1, 1, 0, 1, 0],
+            [10, 'minutes', startDate, 1950, 1, 1, 0, 10, 0],
+            [100, 'minutes', startDate, 1950, 1, 1, 1, 40, 0],
+            [1000, 'minutes', startDate, 1950, 1, 1, 16, 40, 0],
+            [10000, 'minutes', startDate, 1950, 1, 7, 22, 40, 0],
+
+            [0, 'hours', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'hours', startDate, 1950, 1, 1, 1, 0, 0],
+            [10, 'hours', startDate, 1950, 1, 1, 10, 0, 0],
+            [100, 'hours', startDate, 1950, 1, 5, 4, 0, 0],
+            [1000, 'hours', startDate, 1950, 2, 11, 16, 0, 0],
+            [10000, 'hours', startDate, 1951, 2, 21, 16, 0, 0],
+
+            [0, 'days', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'days', startDate, 1950, 1, 2, 0, 0, 0],
+            [10, 'days', startDate, 1950, 1, 11, 0, 0, 0],
+            [100, 'days', startDate, 1950, 4, 11, 0, 0, 0],
+            [365, 'days', startDate, 1951, 1, 1, 0, 0, 0],
+            [2 * 365, 'days', startDate, 1952, 1, 1, 0, 0, 0],
+            [3 * 365, 'days', startDate, 1952, 12, 31, 0, 0, 0],
+
+            // CF Conventions says to use units months' and 'years'
+            // with caution. Not testing this yet because we haven't
+            // implemented Calendar.msPerUnit to match CF Conventions/
+            // UDUNITS yet.
+        ];
+
+        describe('toCalendarDatetime', function () {
+            each(testCases).it('%d %s since %o', testToCalendarDatetime);
+        });
+
+        describe('fromDatetime', function () {
+            each(testCases).it('works', testFromDatetime);
+        });
+    });
+
+
+    describe('for Fixed365DayCalendar', function () {
+        var startDate = new CalendarDatetime(fixed365DayCalendar, 1950, 1, 1);
+
+        var testCases = [
+            [0, 'seconds', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'seconds', startDate, 1950, 1, 1, 0, 0, 1],
+            [10, 'seconds', startDate, 1950, 1, 1, 0, 0, 10],
+            [100, 'seconds', startDate, 1950, 1, 1, 0, 1, 40],
+            [1000, 'seconds', startDate, 1950, 1, 1, 0, 16, 40],
+            [10000, 'seconds', startDate, 1950, 1, 1, 2, 46, 40],
+            [100000, 'seconds', startDate, 1950, 1, 2, 3, 46, 40],
+
+            [0, 'minutes', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'minutes', startDate, 1950, 1, 1, 0, 1, 0],
+            [10, 'minutes', startDate, 1950, 1, 1, 0, 10, 0],
+            [100, 'minutes', startDate, 1950, 1, 1, 1, 40, 0],
+            [1000, 'minutes', startDate, 1950, 1, 1, 16, 40, 0],
+            [10000, 'minutes', startDate, 1950, 1, 7, 22, 40, 0],
+
+            [0, 'hours', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'hours', startDate, 1950, 1, 1, 1, 0, 0],
+            [10, 'hours', startDate, 1950, 1, 1, 10, 0, 0],
+            [100, 'hours', startDate, 1950, 1, 5, 4, 0, 0],
+            [1000, 'hours', startDate, 1950, 2, 11, 16, 0, 0],
+            [10000, 'hours', startDate, 1951, 2, 21, 16, 0, 0],
+
+            [0, 'days', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'days', startDate, 1950, 1, 2, 0, 0, 0],
+            [10, 'days', startDate, 1950, 1, 11, 0, 0, 0],
+            [100, 'days', startDate, 1950, 4, 11, 0, 0, 0],
+            [365, 'days', startDate, 1951, 1, 1, 0, 0, 0],
+            [2 * 365, 'days', startDate, 1952, 1, 1, 0, 0, 0],
+            [3 * 365, 'days', startDate, 1953, 1, 1, 0, 0, 0],
+
+            // CF Conventions says to use units months' and 'years'
+            // with caution. Not testing this yet because we haven't
+            // implemented Calendar.msPerUnit to match CF Conventions/
+            // UDUNITS yet.
+        ];
+
+        describe('toCalendarDatetime', function () {
+            each(testCases).it('%d %s since %o', testToCalendarDatetime);
+        });
+
+        describe('fromDatetime', function () {
+            each(testCases).it('works', testFromDatetime);
+        });
+    });
+
+    describe('for Fixed360DayCalendar', function () {
+        var startDate = new CalendarDatetime(fixed360DayCalendar, 1950, 1, 1);
+
+        var testCases = [
+            [0, 'seconds', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'seconds', startDate, 1950, 1, 1, 0, 0, 1],
+            [10, 'seconds', startDate, 1950, 1, 1, 0, 0, 10],
+            [100, 'seconds', startDate, 1950, 1, 1, 0, 1, 40],
+            [1000, 'seconds', startDate, 1950, 1, 1, 0, 16, 40],
+            [10000, 'seconds', startDate, 1950, 1, 1, 2, 46, 40],
+            [100000, 'seconds', startDate, 1950, 1, 2, 3, 46, 40],
+
+            [0, 'minutes', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'minutes', startDate, 1950, 1, 1, 0, 1, 0],
+            [10, 'minutes', startDate, 1950, 1, 1, 0, 10, 0],
+            [100, 'minutes', startDate, 1950, 1, 1, 1, 40, 0],
+            [1000, 'minutes', startDate, 1950, 1, 1, 16, 40, 0],
+            [10000, 'minutes', startDate, 1950, 1, 7, 22, 40, 0],
+
+            [0, 'hours', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'hours', startDate, 1950, 1, 1, 1, 0, 0],
+            [10, 'hours', startDate, 1950, 1, 1, 10, 0, 0],
+            [100, 'hours', startDate, 1950, 1, 5, 4, 0, 0],
+            [1000, 'hours', startDate, 1950, 2, 12, 16, 0, 0],
+
+            [0, 'days', startDate, 1950, 1, 1, 0, 0, 0],
+            [1, 'days', startDate, 1950, 1, 2, 0, 0, 0],
+            [10, 'days', startDate, 1950, 1, 11, 0, 0, 0],
+            [100, 'days', startDate, 1950, 4, 11, 0, 0, 0],
+            [360, 'days', startDate, 1951, 1, 1, 0, 0, 0],
+            [2 * 360, 'days', startDate, 1952, 1, 1, 0, 0, 0],
+            [3 * 360, 'days', startDate, 1953, 1, 1, 0, 0, 0],
+
+            // CF Conventions says to use units months' and 'years'
+            // with caution. Not testing this yet because we haven't
+            // implemented Calendar.msPerUnit to match CF Conventions/
+            // UDUNITS yet.
+        ];
+
+        describe('toCalendarDatetime', function () {
+            each(testCases).it('%d %s since %o', testToCalendarDatetime);
+        });
+
+        describe('fromDatetime', function () {
+            each(testCases).it('works', testFromDatetime);
+        });
+    });
+});
+
+
+describe('', function () {
+    it('', function () {
+
+    });
+});

--- a/pdp/static/js/__test__/calendars.test.js
+++ b/pdp/static/js/__test__/calendars.test.js
@@ -1,5 +1,3 @@
-var each = require('jest-each').default;
-
 require('./globals-helpers').importGlobals([
     { module: 'js/condExport', name: 'condExport' },
     { module: 'js/classes.js', name: 'classes' },
@@ -38,20 +36,20 @@ function leapDaysSinceEpoch(calendar, year) {
 
 
 describe('formatDatetimeRaw', function () {
-    each([
+    it.each([
         [1900, 1, 2, 3, 4, 5, '1900-1-2T3-4-5'],
         [undefined, 1, 2, 3, 4, 5, 'undefined-1-2T3-4-5'],
-    ]).it('%#',
+    ])('%#',
         function (year, month, day, hour, minute, second, expected) {
             expect(formatDatetimeRaw(
                 year, month, day, hour, minute, second
             )).toBe(expected);
-        });
+    });
 });
 
 
 describe('formatDatetimeISO8601', function () {
-    each([
+    it.each([
         [1900, 1, 2, 3, 4, 5, '1900-01-02T03:04:05'],
         [1900, 11, 12, 13, 14, 15, '1900-11-12T13:14:15'],
         [undefined, 11, 12, 13, 14, 15, ''],
@@ -60,17 +58,17 @@ describe('formatDatetimeISO8601', function () {
         [1900, 11, 12, undefined, 14, 15, '1900-11-12'],
         [1900, 11, 12, 13, undefined, 15, '1900-11-12T13'],
         [1900, 11, 12, 13, 14, undefined, '1900-11-12T13:14'],
-    ]).it('%#',
+    ])('%#',
         function (year, month, day, hour, minute, second, expected) {
             expect(formatDatetimeISO8601(
                 year, month, day, hour, minute, second
             )).toBe(expected);
-        });
+    });
 });
 
 
 describe('all classes', function () {
-    each([
+    describe.each([
         SimpleDatetime,
         Calendar,
         GregorianCalendar,
@@ -79,7 +77,7 @@ describe('all classes', function () {
         CalendarDatetime,
         CfTimeSystem,
         CfDatetime
-    ]).describe('%s', function (Class) {
+    ])('%s', function (Class) {
         it('cannot be called as a function', function () {
             expect(function () {
                 Class();
@@ -112,19 +110,21 @@ describe('SimpleDatetime', function () {
 
 
     describe('fromIso8601', function () {
-        each([
+        it.each([
             ['1900-01-02T06:07:08', 1900, 1, 2, 6, 7, 8],
             ['1900-1-2T6:7:8', 1900, 1, 2, 6, 7, 8],
             ['1900-01-02', 1900, 1, 2, 0, 0, 0],
             ['1900-01', 1900, 1, 0, 0, 0, 0],
             ['1900', 1900, 1, 0, 0, 0, 0],
-        ]).it('parses the valid string %s',
+        ])('parses the valid string %s',
             function (string, year, month, day, hour, minute, second) {
-            var expected = new SimpleDatetime(year, month, day, hour, minute, second);
-            expect(SimpleDatetime.fromIso8601(string)).toEqual(expected);
-        });
+                var expected = new SimpleDatetime(
+                  year, month, day, hour, minute, second);
+                expect(SimpleDatetime.fromIso8601(string)).toEqual(expected);
+            }
+        );
 
-        each([
+        it.each([
             'x',
             'xxxx',
             '190',
@@ -132,10 +132,12 @@ describe('SimpleDatetime', function () {
             '1900-x',
             '1900-01-xx',
             '1900-01-02Txx',
-        ]).it('returns null for the invalid string %s',
+        ])('returns null for the invalid string %s',
             function (string) {
-            expect(function() { SimpleDatetime.fromIso8601(string) }).toThrow();
-        });
+                expect(function() { SimpleDatetime.fromIso8601(string) })
+                    .toThrow();
+            }
+        );
     });
 });
 
@@ -144,7 +146,7 @@ describe('Calendar', function () {
     var calendar = new Calendar();
 
     describe('isValidTime', function () {
-        each([
+        it.each([
             // one undefined
             [undefined, 1, 2, false],
             [1, undefined, 2, false],
@@ -167,10 +169,11 @@ describe('Calendar', function () {
             [24, 0, 0, false],
             [0, 60, 0, false],
             [0, 0, 60, false],
-        ]).it('%d-%d-%d: %s',
+        ])('%d-%d-%d: %s',
             function (hour, minute, second, expected) {
                 expect(calendar.isValidTime(hour, minute, second)).toBe(expected);
-            });
+            }
+        );
     });
 
 });
@@ -188,7 +191,7 @@ describe('GregorianCalendar', function () {
     });
 
     describe('isValidDate', function () {
-        each([
+        it.each([
             [undefined, 1, 1, false],
             [1900, undefined, 1, false],
             [1900, 1, undefined, true],
@@ -206,29 +209,31 @@ describe('GregorianCalendar', function () {
 
             [1901, 2, 28, true],
             [1901, 2, 29, false],
-        ]).it('%d-%d-%d: %s',
+        ])('%d-%d-%d: %s',
             function (year, month, day, expected) {
                 expect(calendar.isValidDate(year, month, day)).toBe(expected);
-            });
+            }
+        );
     });
 
     describe('validateDatetime', function () {
-        each([
+        it.each([
             [undefined, 1, 1, 1, 1, 1],
             [1901, 2, 29, 1, 1, 1],
             [1901, 1, 1, 99, 1, 1],
-        ]).it('',
+        ])('',
             function (year, month, day, hour, minute, second) {
                 expect(
                     function () {
                         calendar.validateDatetime(year, month, day, hour, minute, second)
                     }
                 ).toThrow();
-            });
+            }
+        );
     });
 
     describe('isLeapYear', function () {
-        each([
+        it.each([
             [1600, true],
             [1700, false],
             [1800, false],
@@ -242,39 +247,41 @@ describe('GregorianCalendar', function () {
             [2002, false],
             [2003, false],
             [2004, true],
-        ]).it('correctly determines if %d is a leap year',
+        ])('correctly determines if %d is a leap year',
             function (year, expected) {
                 expect(calendar.isLeapYear(year)).toBe(expected);
             });
     });
 
     describe('daysPerYear', function () {
-        each([
+        it.each([
             [1900, 365],
             [1901, 365],
             [2000, 366],
-        ]).it('correctly returns the number of days for year %d',
+        ])('correctly returns the number of days for year %d',
             function (year, days) {
                 expect(calendar.daysPerYear(year)).toBe(days);
-            });
+            }
+        );
     });
 
     describe('daysPerMonth', function () {
-        each([
+        it.each([
             [1900, 1, 31],
             [1900, 2, 28],
             [1900, 3, 31],
             [1900, 4, 30],
             [1904, 2, 29],
             [2000, 2, 29],
-        ]).it('correctly returns the number of days for month %d-%d',
+        ])('correctly returns the number of days for month %d-%d',
             function (year, month, days) {
                 expect(calendar.daysPerMonth(year, month)).toBe(days);
-            });
+            }
+        );
     });
 
     describe('msPerUnit', function () {
-        each([
+        it.each([
             ['second', undefined, undefined, 1000],
             ['day', undefined, undefined, msPerDay],
             ['month', 1901, 1, 31 * msPerDay],
@@ -289,10 +296,11 @@ describe('GregorianCalendar', function () {
             ['year', 1902, undefined, 365 * msPerDay],
             ['year', 1903, undefined, 365 * msPerDay],
             ['year', 1904, undefined, 366 * msPerDay],
-        ]).it('correctly computes ms per %s for %d-%d',
+        ])('correctly computes ms per %s for %d-%d',
             function (unit, year, month, ms) {
                 expect(calendar.msPerUnit(unit, year, month)).toBe(ms);
-            });
+            }
+        );
     });
 
     var dateTimeMsSinceEpoch = [
@@ -327,19 +335,21 @@ describe('GregorianCalendar', function () {
     ];
 
     describe('msSinceEpoch', function () {
-        each(dateTimeMsSinceEpoch)
-        .it('correctly converts FROM %o TO %d ms since epoch',
+        it.each(dateTimeMsSinceEpoch)(
+            'correctly converts FROM %o TO %d ms since epoch',
             function (datetime, ms) {
                 expect(calendar.msSinceEpoch(datetime)).toBe(ms);
-            });
+            }
+        );
     });
 
     describe('simpleDatetimeFromMsSinceEpoch', function () {
-        each(dateTimeMsSinceEpoch)
-        .it('correctly converts TO %o FROM %d ms since epoch',
+        it.each(dateTimeMsSinceEpoch)(
+            'correctly converts TO %o FROM %d ms since epoch',
             function (datetime, ms) {
                 expect(calendar.simpleDatetimeFromMsSinceEpoch(ms)).toEqual(datetime);
-            });
+            }
+        );
     });
 });
 
@@ -353,7 +363,7 @@ describe('Fixed365DayCalendar', function () {
     });
 
     describe('isValidDate', function () {
-        each([
+        it.each([
             [undefined, 1, 1, false],
             [1900, undefined, 1, false],
             [1900, 1, undefined, true],
@@ -372,59 +382,63 @@ describe('Fixed365DayCalendar', function () {
 
             [1901, 2, 28, true],
             [1901, 2, 29, false],
-        ]).it('%d-%d-%d: %s',
+        ])('%d-%d-%d: %s',
             function (year, month, day, expected) {
                 expect(calendar.isValidDate(year, month, day)).toBe(expected);
-            });
+            }
+        );
     });
 
     describe('validateDatetime', function () {
-        each([
+        it.each([
             [undefined, 1, 1, 1, 1, 1],
             [1901, 2, 29, 1, 1, 1],
             [1901, 1, 1, 99, 1, 1],
-        ]).it('',
+        ])('',
             function (year, month, day, hour, minute, second) {
                 expect(
                     function () {
                         calendar.validateDatetime(year, month, day, hour, minute, second)
                     }
                 ).toThrow();
-            });
+            }
+        );
     });
 
     describe('isLeapYear', function () {
-        each([
+        it.each([
             1900, 1901, 1904, 2000, 2001, 2100
-        ]).it('correctly says %d is not a leap year', function (year) {
+        ])('correctly says %d is not a leap year', function (year) {
             expect(calendar.isLeapYear(year)).toBe(false);
         });
     });
 
     describe('daysPerYear', function () {
-        each([
+        it.each([
             1900, 1901, 1904, 2000, 2001, 2100
-        ]).it('correctly says there are 365 days in every year',
+        ])('correctly says there are 365 days in every year',
             function (year) {
                 expect(calendar.daysPerYear(year)).toBe(365);
-            });
+            }
+        );
     });
 
     describe('daysPerMonth', function () {
-        each([
+        it.each([
             [1900, 1, 31],
             [1900, 2, 28],
             [1900, 3, 31],
             [1900, 4, 30],
             [2000, 2, 28],
-        ]).it('correctly returns the number of days for month %d-%d',
+        ])('correctly returns the number of days for month %d-%d',
             function (year, month, days) {
                 expect(calendar.daysPerMonth(year, month)).toBe(days);
-            });
+            }
+        );
     });
 
     describe('msPerUnit', function () {
-        each([
+        it.each([
             ['second', undefined, undefined, 1000],
             ['day', undefined, undefined, msPerDay],
             ['month', 1901, 1, 31 * msPerDay],
@@ -437,10 +451,11 @@ describe('Fixed365DayCalendar', function () {
             ['year', 1901, undefined, 365 * msPerDay],
             ['year', 1902, undefined, 365 * msPerDay],
             ['year', 1903, undefined, 365 * msPerDay],
-        ]).it('correctly computes ms per %s for %d-%d',
+        ])('correctly computes ms per %s for %d-%d',
             function (unit, year, month, ms) {
                 expect(calendar.msPerUnit(unit, year, month)).toBe(ms);
-            });
+            }
+        );
     });
 
     var dateTimeMsSinceEpoch = [
@@ -475,19 +490,21 @@ describe('Fixed365DayCalendar', function () {
     ];
 
     describe('msSinceEpoch', function () {
-        each(dateTimeMsSinceEpoch)
-        .it('correctly converts FROM %o TO %d ms since epoch',
+        it.each(dateTimeMsSinceEpoch)(
+            'correctly converts FROM %o TO %d ms since epoch',
             function (datetime, ms) {
                 expect(calendar.msSinceEpoch(datetime)).toBe(ms);
-            });
+            }
+        );
     });
 
     describe('simpleDatetimeFromMsSinceEpoch', function () {
-        each(dateTimeMsSinceEpoch)
-        .it('correctly converts TO %o FROM %d ms since epoch',
+        it.each(dateTimeMsSinceEpoch)(
+            'correctly converts TO %o FROM %d ms since epoch',
             function (datetime, ms) {
                 expect(calendar.simpleDatetimeFromMsSinceEpoch(ms)).toEqual(datetime);
-            });
+            }
+        );
     });
 });
 
@@ -501,7 +518,7 @@ describe('Fixed360DayCalendar', function () {
     });
 
     describe('isValidDate', function () {
-        each([
+        it.each([
             [undefined, 1, 1, false],
             [1900, undefined, 1, false],
             [1900, 1, undefined, true],
@@ -519,59 +536,61 @@ describe('Fixed360DayCalendar', function () {
 
             [1901, 2, 28, true],
             [1901, 2, 29, true],
-        ]).it('%d-%d-%d: %s',
+        ])('%d-%d-%d: %s',
             function (year, month, day, expected) {
                 expect(calendar.isValidDate(year, month, day)).toBe(expected);
-            });
+            }
+        );
     });
 
     describe('validateDatetime', function () {
-        each([
+        it.each([
             [undefined, 1, 1, 1, 1, 1],
             [1901, 2, 33, 1, 1, 1],
             [1901, 1, 1, 99, 1, 1],
-        ]).it('',
+        ])('',
             function (year, month, day, hour, minute, second) {
                 expect(
                     function () {
                         calendar.validateDatetime(year, month, day, hour, minute, second)
                     }
                 ).toThrow();
-            });
+            }
+        );
     });
 
     describe('isLeapYear', function () {
-        each([
+        it.each([
             1900, 1901, 1904, 2000, 2001, 2100
-        ]).it('correctly says %d is not a leap year', function (year) {
+        ])('correctly says %d is not a leap year', function (year) {
             expect(calendar.isLeapYear(year)).toBe(false);
         });
     });
 
     describe('daysPerYear', function () {
-        each([
+        it.each([
             1900, 1901, 1904, 2000, 2001, 2100
-        ]).it('correctly says there are 360 days in %d',
-            function (year) {
-                expect(calendar.daysPerYear(year)).toBe(360);
-            });
+        ])('correctly says there are 360 days in %d', function (year) {
+            expect(calendar.daysPerYear(year)).toBe(360);
+        });
     });
 
     describe('daysPerMonth', function () {
-        each([
+        it.each([
             [1900, 1],
             [1900, 2],
             [1900, 3],
             [1900, 4],
             [2000, 2],
-        ]).it('correctly returns the number of days for month %d-%d',
+        ])('correctly returns the number of days for month %d-%d',
             function (year, month) {
                 expect(calendar.daysPerMonth(year, month)).toBe(30);
-            });
+            }
+        );
     });
 
     describe('msPerUnit', function () {
-        each([
+        it.each([
             ['second', undefined, undefined, 1000],
             ['day', undefined, undefined, msPerDay],
             ['month', 1901, 1, 30 * msPerDay],
@@ -584,10 +603,11 @@ describe('Fixed360DayCalendar', function () {
             ['year', 1901, undefined, 360 * msPerDay],
             ['year', 1902, undefined, 360 * msPerDay],
             ['year', 1903, undefined, 360 * msPerDay],
-        ]).it('correctly computes ms per %s for %d-%d',
+        ])('correctly computes ms per %s for %d-%d',
             function (unit, year, month, ms) {
                 expect(calendar.msPerUnit(unit, year, month)).toBe(ms);
-            });
+            }
+        );
     });
 
     var dateTimeMsSinceEpoch = [
@@ -622,26 +642,27 @@ describe('Fixed360DayCalendar', function () {
     ];
 
     describe('msSinceEpoch', function () {
-        each(dateTimeMsSinceEpoch)
-        .it('correctly converts FROM %o TO %d ms since epoch',
+        it.each(dateTimeMsSinceEpoch)(
+            'correctly converts FROM %o TO %d ms since epoch',
             function (datetime, ms) {
                 expect(calendar.msSinceEpoch(datetime)).toBe(ms);
-            });
+            }
+        );
     });
 
     describe('simpleDatetimeFromMsSinceEpoch', function () {
-        each(dateTimeMsSinceEpoch)
-        .it('correctly converts TO %o FROM %d ms since epoch',
+        it.each(dateTimeMsSinceEpoch)('correctly converts TO %o FROM %d ms since epoch',
             function (datetime, ms) {
                 expect(calendar.simpleDatetimeFromMsSinceEpoch(ms)).toEqual(datetime);
-            });
+            }
+        );
     });
 });
 
 
 describe('CalendarDatetime', function () {
     describe('toMsSinceEpoch', function () {
-        each([
+        it.each([
             [gregorianCalendar, 1900, 1, 1, 0, 0, 0, 0],
             [fixed365DayCalendar, 1900, 1, 1, 0, 0, 0, 0],
             [fixed360DayCalendar, 1900, 1, 1, 0, 0, 0, 0],
@@ -652,7 +673,7 @@ describe('CalendarDatetime', function () {
                 msPerDay * (50 * 365)],
             [fixed360DayCalendar, 1950, 1, 1, 0, 0, 0,
                 msPerDay * (50 * 360)],
-        ]).it('',
+        ])('',
             function (
                 calendar, year, month, day, hour, minute, second, ms
             ) {
@@ -660,7 +681,8 @@ describe('CalendarDatetime', function () {
                     calendar, year, month, day, hour, minute, second
                 );
                 expect(cdt.toMsSinceEpoch()).toBe(ms);
-            });
+            }
+        );
     });
 });
 
@@ -680,8 +702,7 @@ describe('CalendarFactory', function () {
             return type;
         }
 
-        each(CalendarFactory.calendarTypes)
-        .it('%s', function (type) {
+        it.each(CalendarFactory.calendarTypes)('%s', function (type) {
             var calendar = calendarFactory.createCalendar(type);
             expect(calendar.type).toBe(reducedType(type));
         });
@@ -762,11 +783,11 @@ describe('CfDatetime', function () {
         ];
 
         describe('toCalendarDatetime', function () {
-            each(testCases).it('%d %s since %o', testToCalendarDatetime);
+            it.each(testCases)('%d %s since %o', testToCalendarDatetime);
         });
 
         describe('fromDatetime', function () {
-            each(testCases).it('works', testFromDatetime);
+            it.each(testCases)('works', testFromDatetime);
         });
     });
 
@@ -812,11 +833,16 @@ describe('CfDatetime', function () {
         ];
 
         describe('toCalendarDatetime', function () {
-            each(testCases).it('%d %s since %o', testToCalendarDatetime);
+describe('', function () {
+    it('', function () {
+
+    });
+});
+            it.each(testCases)('%d %s since %o', testToCalendarDatetime);
         });
 
         describe('fromDatetime', function () {
-            each(testCases).it('works', testFromDatetime);
+            it.each(testCases)('works', testFromDatetime);
         });
     });
 
@@ -860,18 +886,11 @@ describe('CfDatetime', function () {
         ];
 
         describe('toCalendarDatetime', function () {
-            each(testCases).it('%d %s since %o', testToCalendarDatetime);
+            it.each(testCases)('%d %s since %o', testToCalendarDatetime);
         });
 
         describe('fromDatetime', function () {
-            each(testCases).it('works', testFromDatetime);
+            it.each(testCases)('works', testFromDatetime);
         });
-    });
-});
-
-
-describe('', function () {
-    it('', function () {
-
     });
 });

--- a/pdp/static/js/__test__/calendars.test.js
+++ b/pdp/static/js/__test__/calendars.test.js
@@ -795,6 +795,7 @@ describe('CfDatetime', function () {
             [100000, 'seconds', startDate, 1950, 1, 2, 3, 46, 40],
 
             [0, 'minutes', startDate, 1950, 1, 1, 0, 0, 0],
+            [0.5, 'minutes', startDate, 1950, 1, 1, 0, 0, 30],
             [1, 'minutes', startDate, 1950, 1, 1, 0, 1, 0],
             [10, 'minutes', startDate, 1950, 1, 1, 0, 10, 0],
             [100, 'minutes', startDate, 1950, 1, 1, 1, 40, 0],
@@ -803,6 +804,7 @@ describe('CfDatetime', function () {
 
             [0, 'hours', startDate, 1950, 1, 1, 0, 0, 0],
             [1, 'hours', startDate, 1950, 1, 1, 1, 0, 0],
+            [1.1, 'hours', startDate, 1950, 1, 1, 1, 6, 0],
             [10, 'hours', startDate, 1950, 1, 1, 10, 0, 0],
             [100, 'hours', startDate, 1950, 1, 5, 4, 0, 0],
             [1000, 'hours', startDate, 1950, 2, 11, 16, 0, 0],
@@ -811,6 +813,7 @@ describe('CfDatetime', function () {
             [0, 'days', startDate, 1950, 1, 1, 0, 0, 0],
             [1, 'days', startDate, 1950, 1, 2, 0, 0, 0],
             [10, 'days', startDate, 1950, 1, 11, 0, 0, 0],
+            [10.5, 'days', startDate, 1950, 1, 11, 12, 0, 0],
             [100, 'days', startDate, 1950, 4, 11, 0, 0, 0],
             [365, 'days', startDate, 1951, 1, 1, 0, 0, 0],
             [2 * 365, 'days', startDate, 1952, 1, 1, 0, 0, 0],
@@ -873,11 +876,6 @@ describe('CfDatetime', function () {
         ];
 
         describe('toCalendarDatetime', function () {
-describe('', function () {
-    it('', function () {
-
-    });
-});
             it.each(testCases)('%d %s since %o', testToCalendarDatetime);
         });
 

--- a/pdp/static/js/__test__/calendars.test.js
+++ b/pdp/static/js/__test__/calendars.test.js
@@ -693,11 +693,15 @@ describe('CalendarFactory', function () {
     describe('makeCalendar', function () {
         function reducedType(type) {
             if (
-                type === 'standard' ||
                 type === 'gregorian' ||
                 type === 'proleptic_gregorian'
             ) {
                 return 'standard';
+            }
+            if (
+                type === 'noleap'
+            ) {
+                return '365_day';
             }
             return type;
         }

--- a/pdp/static/js/__test__/calendars.test.js
+++ b/pdp/static/js/__test__/calendars.test.js
@@ -37,8 +37,8 @@ function leapDaysSinceEpoch(calendar, year) {
 
 describe('formatDatetimeRaw', function () {
     it.each([
-        [1900, 1, 2, 3, 4, 5, '1900-1-2T3-4-5'],
-        [undefined, 1, 2, 3, 4, 5, 'undefined-1-2T3-4-5'],
+        [1900, 1, 2, 3, 4, 5, '1900-1-2T3:4:5'],
+        [undefined, 1, 2, 3, 4, 5, 'undefined-1-2T3:4:5'],
     ])('%#',
         function (year, month, day, hour, minute, second, expected) {
             expect(formatDatetimeRaw(

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -703,7 +703,7 @@
 
     function CfDatetime(system, index) {
         // `system`: `CfTimeSystem`
-        // `index`: `integer`
+        // `index`: `Number`
         classes.classCallCheck(this, CfDatetime);
         classes.validateClass(system, CfTimeSystem, 'system');
         this.system = system;

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -656,12 +656,22 @@
         },
 
         todayAsCfDatetime: function() {
-            // Return today's date as a `CfDatetime`.
+            // Return today's date as a `CfDatetime` ...
+            // or the latest valid date before or equal to today in the
+            // system's calendar.
             var today = new Date();
-            return new CfDatetime.fromDatetime(
-                this,
-                today.getFullYear(), today.getMonth()+1, today.getDay()
-            );
+            while (true) {
+                try {
+                    return new CfDatetime.fromDatetime(
+                      this,
+                      today.getFullYear(), today.getMonth()+1, today.getDate()
+                    );
+                } catch {
+                    // Decrement by one day. This happens at most once to
+                    // reach a valid date in any non-Gregorian calendar.
+                    today.setDate(today.getDate() - 1);
+                }
+            }
         }
     }, {
     });

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -534,6 +534,7 @@
                 case 'proleptic_gregorian':
                     return new GregorianCalendar(this.epochYear);
                 case '365_day':
+                case 'noleap':
                     return new Fixed365DayCalendar(this.epochYear);
                 case '360_day':
                     return new Fixed360DayCalendar(this.epochYear);
@@ -544,7 +545,7 @@
     }, {
         calendarTypes: [
             'standard', 'gregorian', 'proleptic_gregorian',
-            '365_day', '360_day'
+            '365_day', 'noleap', '360_day'
         ]
     });
 

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -765,10 +765,9 @@
             var datetime = new CalendarDatetime(
                 calendar, year, month, day, hour, minute, second
             );
-            var index = Math.floor(
+            var index =
                 (datetime.toMsSinceEpoch() - startDate.toMsSinceEpoch()) /
-                calendar.msPerUnit(system.units)
-            );
+                calendar.msPerUnit(system.units);
             try {
                 return new CfDatetime(system, index);
             } catch(error) {

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -75,7 +75,7 @@
         // ISO 8601-like format, but without any checking or fancy formatting.
         // Useful for error messages.
         return '' + year + '-' + month + '-' + day +
-            'T' + hour + '-' + minute + '-' + second;
+            'T' + hour + ':' + minute + ':' + second;
     }
 
     var formatDatetimeISO8601 = makeFormatDatetime(

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -1,0 +1,788 @@
+/*globals classes */
+
+// TODO: This code is logical and works, but its API is hard to remember and
+// inconvenient to use. Refactor and/or add some convenience metods.
+
+(function () {
+    // Utility functions
+    
+    function toInt(string) {
+        if (!string) {
+            return undefined;
+        }
+        return parseInt(string, 10);
+    }
+
+    function isUndefined(v) {
+        return typeof v === 'undefined';
+    }
+
+    var isInteger = Number.isInteger;
+
+    var isArray = Array.isArray;
+
+    function isInRange(v, min, max) {
+        return min <= v && v < max;
+    }
+
+    function format(places, num) {
+        if (isUndefined(num)) {
+            return undefined;
+        }
+        var s = '00000000000' + num;
+        return s.substr(s.length - places);
+    }
+
+    var format2 = format.bind(this, 2);
+    var format4 = format.bind(this, 4);
+
+    function appendParts(to, parts, formats, sep) {
+        var formattedParts = [];
+        for (var i = 0; i < parts.length; i++) {
+            var part = parts[i];
+            if (isUndefined(part)) break;
+            var format = isArray(formats) ? formats[i] : formats;
+            formattedParts.push(format(part));
+        }
+        return to + formattedParts.join(sep);
+    }
+
+    function makeFormatDatetime(formats, ymdSep, timeDelim, hmsSep) {
+        return function formatDateTime(year, month, day, hour, minute, second) {
+            var dateOnly = appendParts(
+                '',
+                [year, month, day],
+                formats,
+                ymdSep
+            );
+            if (dateOnly.length < 10 || isUndefined(hour)) {
+                return dateOnly;
+            }
+            return appendParts(
+                dateOnly + timeDelim,
+                [hour, minute, second],
+                isArray(formats) ? formats.slice(3) : formats,
+                hmsSep
+            );
+        }
+    }
+
+
+    function formatDatetimeRaw(year, month, day, hour, minute, second) {
+        // Return a string representing the argument values in an
+        // ISO 8601-like format, but without any checking or fancy formatting.
+        // Useful for error messages.
+        return '' + year + '-' + month + '-' + day +
+            'T' + hour + '-' + minute + '-' + second;
+    }
+
+    var formatDatetimeISO8601 = makeFormatDatetime(
+        [format4, format2, format2, format2, format2, format2],
+        '-', 'T', ':'
+    );
+
+    var formatDatetimeLoose = makeFormatDatetime(
+        [format4, format2, format2, format2, format2, format2],
+        '/', ' ', ':'
+    );
+
+    //  class SimpleDatetime
+    //      static fromIso8601
+    //
+    //  Datetime with no calendar and, consequently, no validation (BEWARE)
+
+    function SimpleDatetime(year, month, day, hour, minute, second) {
+        classes.classCallCheck(this, SimpleDatetime);
+        if (isUndefined(year)) {
+            throw new Error('Year must be defined');
+        }
+        var consArgs = arguments;
+        ['year', 'month', 'day', 'hour', 'minute', 'second']
+        .forEach(function (name, i) {
+            var arg = consArgs[i];
+            if(!(isUndefined(arg) || isInteger(arg))) {
+                throw new Error(
+                    'Parameter "' + name + '" must be undefined or an integer, but was ' + arg);
+            }
+        });
+        this.year = year;
+        this.month = month || 1;
+        this.day = day || 1;
+        this.hour = hour || 0;
+        this.minute = minute || 0;
+        this.second = second || 0;
+    }
+    classes.addClassProperties(SimpleDatetime, {
+        toISOString: function(dateOnly) {
+            if (dateOnly) {
+                return formatDatetimeISO8601(
+                    this.year, this.month, this.day
+                );
+            }
+            return formatDatetimeISO8601(
+                this.year, this.month, this.day,
+                this.hour, this.minute, this.second
+            );
+        },
+
+        toLooseString: function(dateOnly) {
+            if (dateOnly) {
+                return formatDatetimeLoose(
+                    this.year, this.month, this.day
+                );
+            }
+            return formatDatetimeLoose(
+                this.year, this.month, this.day,
+                this.hour, this.minute, this.second
+            );
+        }
+    }, {
+        fromIso8601: function(string) {
+            // Parses an ISO 8601 datetime string.
+            // Returns a corresponding `SimpleDatetime` (calendar-agnostic).
+            // Returns `null` if the string is not a valid ISO 8601
+            // datetime string.
+            //
+            // This is a loose ISO 8601 parser, in two senses:
+            //  - It is more forgiving than the standard. It allows 1-digit
+            //      month, day, hour, minute, and second values.
+            //  - It parses only a subset of the standard, specifically only
+            //      date and time
+
+            var looseIso8601Regex =
+                /^(\d{4})(-(\d{1,2}))?(-(\d{1,2}))?([ T](\d{1,2})(:(\d{1,2}))?(:(\d{1,2}))?)?$/;
+            var match = looseIso8601Regex.exec(string);
+            if (!match) {
+                throw new Error('Date string is not in ISO 8601 date-time format');
+            }
+            return new SimpleDatetime(
+                toInt(match[1]), toInt(match[3]), toInt(match[5]), toInt(match[7]), toInt(match[9]), toInt(match[11])
+            );
+        },
+
+        fromLooseFormat: function(dateString) {
+            // Parses a loose-formatted date string.
+            var looseFormatRegex = /^\s*(\d{4})([\/-](\d{1,2}))?([\/-](\d{1,2}))?\s*$/;
+            var match = looseFormatRegex.exec(dateString);
+            if (!match) {
+                throw new Error(
+                    'Date string is not in acceptable date-time format ' +
+                    '(YYYY/MM/DD or YYYY-MM-DD)');
+            }
+            return new SimpleDatetime(
+                toInt(match[1]), toInt(match[3]), toInt(match[5])
+            );
+        }
+    });
+
+
+    // class Calendar
+    //      epochYear
+    //      abstract type
+    //      abstract name
+    //
+    //      abstract isLeapYear()
+    //      abstract daysPerMonth()
+    //      abstract daysPerYear()
+    //
+    //      isValidTime()
+    //      isValidDate()
+    //      isValidDatetime()
+    //      validateDatetime()
+    //      msPerUnit()
+    //      msSinceEpoch()
+    //      simpleDatetimeFromMsSinceEpoch()
+    //
+    //      static toRawDatetimeFormat()
+    //
+    // Base class for calendar classes.
+    //
+    // Represents a calendar in the sense of a system of managing and relating
+    // time units of seconds, minutes, hours, days, months, years.
+    //
+    // Specialized to a concrete calendar by defining the abstract methods
+    // `isLeapYear`, `daysPerMonth`, `daysPerYear`.
+
+    function Calendar(epochYear) {
+        classes.classCallCheck(this, Calendar);
+        this.epochYear = epochYear || 1800;
+    }
+    classes.addClassProperties(Calendar, {
+        isLeapYear: classes.unimplementedAbstractMethod('isLeapYear'),
+        daysPerMonth: classes.unimplementedAbstractMethod('daysPerMonth'),
+        daysPerYear: classes.unimplementedAbstractMethod('daysPerYear'),
+
+        isValidTime: function (hour, minute, second) {
+            // Self-explanatory
+            // TODO: Add some type-checking
+            var result = true;
+            if (isUndefined(hour)) {
+                result = result && isUndefined(minute) && isUndefined(second);
+            } else {
+                result = result && isInRange(hour, 0, 24);
+            }
+            if (isUndefined(minute)) {
+                result = result && isUndefined(second);
+            } else {
+                result = result && isInRange(minute, 0, 60);
+            }
+            if (!isUndefined(second)) {
+                result = result && isInRange(second, 0, 60);
+            }
+            return result;
+        },
+
+        isValidDate: function (year, month, day) {
+            // Self-explanatory
+            // TODO: Add some type-checking
+            var result = true;
+            if (isUndefined(year)) {
+                result = false;
+            }
+            if (isUndefined(month)) {
+                result = result && isUndefined(day);
+            } else {
+                result = result && isInRange(month, 1, 13);
+            }
+            if (!isUndefined(day)) {
+                result = result &&
+                    isInRange(day, 1, this.daysPerMonth(year, month) + 1);
+            }
+            return result;
+        },
+
+        isValidDatetime: function (year, month, day, hour, minute, second) {
+            // Self-explanatory
+            return this.isValidDate(year, month, day) &&
+                this.isValidTime(hour, minute, second);
+        },
+
+        validateDatetime: function (year, month, day, hour, minute, second) {
+            // Throw an error if the date and time are not valid.
+            if (!this.isValidDatetime(year, month, day, hour, minute, second)) {
+                throw new Error(
+                    'Datetime (' +
+                    formatDatetimeRaw(year, month, day, hour, minute, second) +
+                    ') is not valid for calendar type ' +
+                    this.name
+                )
+            }
+        },
+
+        msPerUnit: function (unit, year, month) {
+            // Return the number of milliseconds per unit.
+            // For the units 'month' and 'year', the value is (potentially)
+            // dependent on the year and month within the calendar.
+            switch (unit) {
+                case 's':
+                case 'sec':
+                case 'second':
+                case 'seconds':
+                    return 1000;
+                case 'min':
+                case 'minute':
+                case 'minutes':
+                    return 60 * this.msPerUnit('second');
+                case 'h':
+                case 'hr':
+                case 'hour':
+                case 'hours':
+                    return 60 * this.msPerUnit('minute');
+                case 'd':
+                case 'day':
+                case 'days':
+                    return 24 * this.msPerUnit('hour');
+                case 'month':
+                case 'months':
+                    return this.daysPerMonth(year, month) *
+                        this.msPerUnit('day');
+                case 'y':
+                case 'yr':
+                case 'year':
+                case 'years':
+                    return this.daysPerYear(year) *
+                        this.msPerUnit('day');
+                default:
+                    throw new Error('Invalid time unit: ' + unit);
+            }
+        },
+
+        msSinceEpoch: function (datetime) {
+            // Returns the number of milliseconds since the epoch, which
+            // is defined as the (calendar-agnostic) date Jan 1, <epochYear>.
+            //
+            // Throws an error if the datetime supplied is not valid for the
+            // calendar.
+            //
+            // This algorithm works correctly for all calendars.
+            // It is a little inefficient for the 365- and 360-day calendars,
+            // and could be overridden in those cases if efficiency is a
+            // concern.
+            //
+            // See documentation `simpleDatetimeFromMsSinceEpoch` for identities
+            // that hold between these two methods.
+
+            this.validateDatetime(
+                datetime.year, datetime.month, datetime.day,
+                datetime.hour, datetime.minute, datetime.second
+            );
+            var _this = this;
+            var result = 0;
+
+            // Add full-year contributions
+            for (var year = this.epochYear; year < datetime.year; year++) {
+                result += _this.msPerUnit('year', year);
+            }
+
+            // Add full-month contributions
+            for (var month = 1; month < datetime.month; month++) {
+                result += _this.msPerUnit('month', datetime.year, month);
+            }
+
+            // Add full-day contributions
+            result += (datetime.day - 1) * _this.msPerUnit('day');
+
+            // Add time (part-day) contributions
+            ['hour', 'minute', 'second'].forEach(function (unit) {
+                result += datetime[unit] * _this.msPerUnit(unit);
+            });
+
+            return result;
+        },
+
+        simpleDatetimeFromMsSinceEpoch: function (ms) {
+            // Returns a `SimpleDatetime` representing the date that is 
+            // exactly `ms` milliseconds from the calendar's epoch.
+            //
+            // Let `cal` be a Calendar. Then the following identities hold:
+            //
+            //      `cal.simpleDatetimeFromMsSinceEpoch(cal.msSinceEpoch(b)) = b`
+            //          for all `b`: `SimpleDatetime`
+            //
+            //      `cal.msSinceEpoch(cal.simpleDatetimeFromMsSinceEpoch(ms))` = ms`
+            //          for all `ms`: `integer`
+            var _this = this;
+            var remaining = ms;
+
+            // Remove full-year contributions
+            for (var year = this.epochYear;
+                 remaining >= _this.msPerUnit('year', year);
+                 year++
+            ) {
+                remaining -= _this.msPerUnit('year', year);
+            }
+
+            // Remove full-month contributions
+            for (var month = 1;
+                 remaining >= _this.msPerUnit('month', year, month);
+                 month++
+            ) {
+                remaining -= _this.msPerUnit('month', year, month);
+            }
+
+            // Calculate the lower-order components.
+            var amounts = {};
+            ['days', 'hour', 'minute', 'second'].forEach(function (unit) {
+                var msPer = _this.msPerUnit(unit);
+                var amount = Math.floor(remaining / msPer);
+                amounts[unit] = amount;
+                remaining -= amount * msPer;
+            });
+
+            return new SimpleDatetime(
+                year, month, amounts.days + 1,
+                amounts.hour, amounts.minute, amounts.second
+            );
+        }
+    }, {
+        validUnits: [
+            's', 'sec', 'second', 'seconds',
+            'min', 'minute', 'minutes',
+            'h', 'hr', 'hour', 'hours',
+            'd', 'day', 'days',
+            'month', 'months',
+            'y', 'yr', 'year', 'years'
+        ],
+
+
+        isValidUnit: function(unit) {
+            return Calendar.validUnits.indexOf(unit) !== -1;
+        },
+
+        validateUnit: function(unit) {
+            if (!Calendar.isValidUnit(unit)) {
+                throw new Error('Invalid time unit: ' + unit);
+            }
+        },
+    });
+
+
+    // class GregorianCalendar extends Calendar
+    //
+    // Concrete class for representing the Gregorian calendar
+
+    function GregorianCalendar() {
+        classes.classCallCheck(this, GregorianCalendar);
+        Calendar.apply(this, arguments);
+        this.type = 'standard';
+        this.name = 'Gregorian';
+    }
+    classes.inherit(GregorianCalendar, Calendar);
+    classes.addClassProperties(GregorianCalendar, {
+        isLeapYear: function (year) {
+            if (year % 4 !== 0) {
+                return false;
+            }
+            if (year % 100 !== 0) {
+                return true;
+            }
+            return year % 400 === 0;
+        },
+
+        daysPerYear: function (year) {
+            if (this.isLeapYear(year)) {
+                return 366;
+            }
+            return 365;
+        },
+
+        daysPerMonth: function (year, month) {
+            var dpm = [null, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+            if (this.isLeapYear(year) && month === 2) {
+                return 29;
+            }
+            return dpm[month];
+        }
+    });
+
+
+    // class Fixed365DayCalendar extends Calendar
+    //
+    // Concrete class for representing the 365-day calendar
+
+    function Fixed365DayCalendar() {
+        classes.classCallCheck(this, Fixed365DayCalendar);
+        Calendar.apply(this, arguments);
+        this.type = '365_day';
+        this.name = 'Fixed 365-day';
+    }
+    classes.inherit(Fixed365DayCalendar, Calendar);
+    classes.addClassProperties(Fixed365DayCalendar, {
+        isLeapYear: function () {
+            return false;
+        },
+
+        daysPerYear: function () {
+            return 365;
+        },
+
+        daysPerMonth: function (year, month) {
+            var dpm = [null, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+            return dpm[month];
+        }
+    });
+
+
+    // class Fixed360DayCalendar extends Calendar
+    //
+    // Concrete class for representing the 360-day calendar
+
+    function Fixed360DayCalendar() {
+        classes.classCallCheck(this, Fixed360DayCalendar);
+        Calendar.apply(this, arguments);
+        this.type = '360_day';
+        this.name = 'Fixed 360-day';
+    }
+    classes.inherit(Fixed360DayCalendar, Calendar);
+    classes.addClassProperties(Fixed360DayCalendar, {
+        isLeapYear: function () {
+            return false;
+        },
+
+        daysPerYear: function () {
+            return 360;
+        },
+
+        daysPerMonth: function () {
+            return 30;
+        }
+    });
+
+
+    // class CalendarFactory
+    //      epochYear
+    //
+    //      createCalendar()
+    //
+    //      static calendarTypes
+
+    function CalendarFactory(epochYear) {
+        this.epochYear = epochYear;
+    }
+    classes.addClassProperties(CalendarFactory, {
+        createCalendar: function(type) {
+            // Note we do not presently make any distinction between standard,
+            // Gregorian, and proleptic Gregorian calendars. This is actually wrong,
+            // but it will do.
+            switch (type) {
+                case 'standard':
+                case 'gregorian':
+                case 'proleptic_gregorian':
+                    return new GregorianCalendar(this.epochYear);
+                case '365_day':
+                    return new Fixed365DayCalendar(this.epochYear);
+                case '360_day':
+                    return new Fixed360DayCalendar(this.epochYear);
+                default:
+                    throw new Error('Unknown calendar type: ', type);
+            }
+        }
+    }, {
+        calendarTypes: [
+            'standard', 'gregorian', 'proleptic_gregorian',
+            '365_day', '360_day'
+        ]
+    });
+
+
+    // class CalendarDatetime
+    //      calendar
+    //      datetime
+    //
+    //      toMsSinceEpoch()
+    //
+    //      static fromMsSinceEpoch()
+    //
+    // Datetime with calendar and validation relative to calendar
+
+    function CalendarDatetime(
+        calendar, sdtOrYear, month, day, hour, minute, second
+    ) {
+        classes.classCallCheck(this, CalendarDatetime);
+        classes.validateClass(calendar, Calendar);
+        this.calendar = calendar;
+
+        var datetime;
+        if (sdtOrYear instanceof SimpleDatetime) {
+            datetime = sdtOrYear;
+        } else {
+            datetime = new SimpleDatetime(
+                sdtOrYear, month, day, hour, minute, second);
+        }
+        calendar.validateDatetime(
+            datetime.year, datetime.month, datetime.day,
+            datetime.hour, datetime.minute, datetime.second
+        );
+        this.datetime = datetime;
+    }
+    classes.addClassProperties(CalendarDatetime, {
+        toISOString: function(dateOnly) {
+            return this.datetime.toISOString(dateOnly);
+        },
+
+        toLooseString: function(dateOnly) {
+            return this.datetime.toLooseString(dateOnly);
+        },
+
+        toMsSinceEpoch: function () {
+            // Returns the number of milliseconds between the calendar's epoch
+            // and this datetime.
+            return this.calendar.msSinceEpoch(this.datetime);
+        }
+    }, {
+        fromMsSinceEpoch: function (calendar, ms) {
+            // Factory method
+            // Returns a CalendarDatetime that is the specified number of
+            // milliseconds since the calendar's epoch.
+            var sdt = calendar.simpleDatetimeFromMsSinceEpoch(ms);
+            return new CalendarDatetime(
+                calendar,
+                sdt.year, sdt.month, sdt.day, sdt.hour, sdt.minute, sdt.second
+            );
+        }
+    });
+
+
+    // CfTimeSystem
+    //      units
+    //      startDate
+    //
+    // Represents a CF Conventions time system, which is defined by a calendar,
+    // units, and a start date. In this class, the calendar is part of
+    // `startDate`, which is a `CalendarDatetime`.
+
+    function CfTimeSystem(units, startDate, indexCount) {
+        // Start date is specified with respect to a particular calendar.
+        // `units`: `string`
+        // `startDate`: `CalendarDatetime`
+        // `indexCount`: `int`
+        // TODO: Add conversion from string for startDate
+        classes.classCallCheck(this, CfTimeSystem);
+        Calendar.validateUnit(units);
+        if (!(startDate instanceof CalendarDatetime)) {
+            throw new Error('startDate must be a CalendarDatetime');
+        }
+        classes.validateClass(startDate, CalendarDatetime);
+        this.units = units;
+        this.startDate = startDate;
+        this.indexCount = indexCount;
+    }
+    classes.addClassProperties(CfTimeSystem, {
+        firstCfDatetime: function() {
+            // Return first date (start date, index 0) in this time system as
+            // a `CfDatetime`
+            return new CfDatetime(this, 0);
+        },
+
+        lastCfDatetime: function() {
+            // Return last date (start date, index `indexCount-1`) in this
+            // time system as a `CfDatetime`.
+            // If `indexCount` is undefined, return undefined.
+            // TODO: Should this throw an error instead?
+            if (this.indexCount) {
+                return new CfDatetime(this, this.indexCount-1);
+            }
+            return undefined;
+        },
+
+        todayAsCfDatetime: function() {
+            // Return today's date as a `CfDatetime`.
+            var today = new Date();
+            return new CfDatetime.fromDatetime(
+                this,
+                today.getFullYear(), today.getMonth()+1, today.getDay()
+            );
+        }
+    }, {
+    });
+
+    // CfDatetime
+    //      system
+    //      index
+    //
+    //      toCalendarDatetime()
+    //
+    //      static fromDatetime()
+    //
+    // Represents a time value in a CF time system.
+    //
+    // A CF datetime value corresponds to an index of the time axis; the actual
+    // datetime that the index represents is determined by the CF time system,
+    // and is defined as the datetime that is exactly index * unit-length
+    // after the start date.
+
+    function CfDatetime(system, index) {
+        // `system`: `CfTimeSystem`
+        // `index`: `integer`
+        classes.classCallCheck(this, CfDatetime);
+        classes.validateClass(system, CfTimeSystem, 'system');
+        this.system = system;
+        this.validateIndex(index);
+        this.index = index;
+    }
+    classes.addClassProperties(CfDatetime, {
+        validateIndex: function(index) {
+            if (index < 0) {
+                throw new Error('Index must be >= 0');
+            }
+            if (this.system.indexCount && index >= this.system.indexCount) {
+                throw new Error('Index must be < ' + this.system.indexCount);
+            }
+        },
+
+        setIndex: function(index) {
+            this.validateIndex(index);
+            this.index = index;
+        },
+
+        toIndex: function() {
+            return this.index;
+        },
+
+        toCalendarDatetime: function () {
+            var system = this.system;
+            var startDate = system.startDate;
+            var calendar = startDate.calendar;
+
+            var startMse = startDate.toMsSinceEpoch();
+            var indexMse = this.index * calendar.msPerUnit(system.units);
+
+            return CalendarDatetime.fromMsSinceEpoch(
+                calendar, startMse + indexMse
+            );
+        },
+
+        toISOString: function(dateOnly) {
+            return this.toCalendarDatetime().toISOString(dateOnly);
+        },
+
+        toLooseString: function(dateOnly) {
+            return this.toCalendarDatetime().toLooseString(dateOnly);
+        },
+
+        toLooseDatetimeFormat: function() {
+            return this.toCalendarDatetime().toLooseDatetimeFormat();
+        }
+    }, {
+        fromDatetime: function (system, year, month, day, hour, minute, second) {
+            // Factory method.
+            // Return a CfDatetime in the specified system, corresponding to the
+            // specified datetime.
+            var startDate = system.startDate;
+            var calendar = startDate.calendar;
+            var datetime = new CalendarDatetime(
+                calendar, year, month, day, hour, minute, second
+            );
+            var index = Math.floor(
+                (datetime.toMsSinceEpoch() - startDate.toMsSinceEpoch()) /
+                calendar.msPerUnit(system.units)
+            );
+            try {
+                return new CfDatetime(system, index);
+            } catch(error) {
+                // var msg = error.message.match(/>=/) ?
+                //     'before time system start date' :
+                //     'after time system maximum date';
+                var msg =
+                    (error.message.match(/>=/) &&
+                        'Date is before time system start date') ||
+                    (error.message.match(/</) &&
+                        'Date is after time system maximum date') ||
+                    error.message;
+                throw new Error(msg)
+            }
+        },
+
+        fromLooseFormat: function(system, string) {
+            var sdt = SimpleDatetime.fromLooseFormat(string);
+            return CfDatetime.fromDatetime(
+                system,
+                sdt.year, sdt.month, sdt.day,
+                sdt.hour, sdt.minute, sdt.second
+            );
+        }
+    });
+
+
+    var exports = {
+        formatDatetimeRaw: formatDatetimeRaw,
+        formatDatetimeISO8601: formatDatetimeISO8601,
+        SimpleDatetime: SimpleDatetime,
+        Calendar: Calendar,
+        GregorianCalendar: GregorianCalendar,
+        Fixed365DayCalendar: Fixed365DayCalendar,
+        Fixed360DayCalendar: Fixed360DayCalendar,
+        CalendarFactory: CalendarFactory,
+        CalendarDatetime: CalendarDatetime,
+        CfTimeSystem: CfTimeSystem,
+        CfDatetime: CfDatetime
+    };
+
+    // Predefined convenience calendars.
+    var calendarFactory = new CalendarFactory();
+    CalendarFactory.calendarTypes.forEach(function(type) {
+        exports[type] = calendarFactory.createCalendar(type);
+    });
+
+    condExport(module, exports, 'calendars');
+})();

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -667,7 +667,7 @@
                       this,
                       today.getFullYear(), today.getMonth()+1, today.getDate()
                     );
-                } catch {
+                } catch(error) {
                     // Decrement by one day. This happens at most once to
                     // reach a valid date in any non-Gregorian calendar.
                     today.setDate(today.getDate() - 1);

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -87,7 +87,10 @@
     );
 
     //  class SimpleDatetime
+    //      toISOString
+    //      toLooseString
     //      static fromIso8601
+    //      static fromLooseFormat
     //
     //  Datetime with no calendar and, consequently, no validation (BEWARE)
 
@@ -193,7 +196,9 @@
     //      msSinceEpoch()
     //      simpleDatetimeFromMsSinceEpoch()
     //
-    //      static toRawDatetimeFormat()
+    //      static validUnits
+    //      static isValidUnit
+    //      static validateUnit
     //
     // Base class for calendar classes.
     //
@@ -404,7 +409,6 @@
             'y', 'yr', 'year', 'years'
         ],
 
-
         isValidUnit: function(unit) {
             return Calendar.validUnits.indexOf(unit) !== -1;
         },
@@ -549,6 +553,8 @@
     //      calendar
     //      datetime
     //
+    //      toISOString
+    //      toLooseString
     //      toMsSinceEpoch()
     //
     //      static fromMsSinceEpoch()
@@ -607,6 +613,10 @@
     //      units
     //      startDate
     //
+    //      firstCfDatetime()
+    //      lastCfDatetime()
+    //      todayAsCfDatetime()
+    //
     // Represents a CF Conventions time system, which is defined by a calendar,
     // units, and a start date. In this class, the calendar is part of
     // `startDate`, which is a `CalendarDatetime`.
@@ -660,9 +670,16 @@
     //      system
     //      index
     //
+    //      validateIndex()
+    //      setIndex()
+    //      toIndex()
     //      toCalendarDatetime()
+    //      toISOString()
+    //      toLooseString()
+    //      toLooseDatetimeFormat()
     //
     //      static fromDatetime()
+    //      static fromLooseFormat()
     //
     // Represents a time value in a CF time system.
     //
@@ -691,6 +708,8 @@
         },
 
         setIndex: function(index) {
+            // Yick. Prefer functional style.
+            // As Zathros said of a different tool, "Never use this."
             this.validateIndex(index);
             this.index = index;
         },

--- a/pdp/static/js/calendars.js
+++ b/pdp/static/js/calendars.js
@@ -25,7 +25,9 @@
         return min <= v && v < max;
     }
 
-    function format(places, num) {
+    function leadingZeros(places, num) {
+        // Format an integer with `places` places, padding with leading 0's
+        // as needed.
         if (isUndefined(num)) {
             return undefined;
         }
@@ -33,8 +35,8 @@
         return s.substr(s.length - places);
     }
 
-    var format2 = format.bind(this, 2);
-    var format4 = format.bind(this, 4);
+    var lz2 = leadingZeros.bind(this, 2);
+    var lz4 = leadingZeros.bind(this, 4);
 
     function appendParts(to, parts, formats, sep) {
         var formattedParts = [];
@@ -77,12 +79,12 @@
     }
 
     var formatDatetimeISO8601 = makeFormatDatetime(
-        [format4, format2, format2, format2, format2, format2],
+        [lz4, lz2, lz2, lz2, lz2, lz2],
         '-', 'T', ':'
     );
 
     var formatDatetimeLoose = makeFormatDatetime(
-        [format4, format2, format2, format2, format2, format2],
+        [lz4, lz2, lz2, lz2, lz2, lz2],
         '/', ' ', ':'
     );
 


### PR DESCRIPTION
This PR adds calendar classes. They are divided into the following groups, with subclassing shown by indentation:

* `SimpleDatetime`
* `Calendar`
   * `GregorianCalendar`
   * `Fixed365DayCalendar`
   * `Fixed360DayCalendar`
* `CalendarFactory`
* `CalendarDatetime`
* `CfTimeSystem`
* `CfDatetime`

The signatures of many of the methods, including constructors, that take datetime inputs are not optimal. Some take `SimpleDatetime`, (most) others take the components `year`, `month`, etc. There are also several other places where signatures could be improved, particularly in constructors. But this is workable, if a little rough on the programmer who has constantly to refer to the documentation to remember what the hell arguments to provide to a given method.

I invite feedback on all of this.

Note: The base branch for this PR is i110-main; see #116.