### PR TITLE
Update pupynere-pdp version to fix a MemoryError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ GDAL==2.2
 XlsxWriter==1.0.2
 coards==1.0.5
 h5py==2.7.1
-pupynere-pdp==1.1.5
+pupynere-pdp==1.1.6
 pydap.handlers.hdf5==0.5.2
 pydap.responses.aaigrid==0.7
 pydap.responses.netcdf==0.6.0


### PR DESCRIPTION
Switches to the newest version of `pupynere-pdp`, 1.1.6, which has been updated to improve memory handling during downloads from datasets with no record variables. The memory allocations for large requested datafiles were sometimes resulting in `MemoryError`s, and were probably slowing down the system even when there were no visible errors.

Previously, when `pupynere-pdp` created a nonrecord netcdf variable, it would allocate memory to hold that variable's data. This was unnecessary for the PDP, since pupynere-pdp isn't even used to stream data; it is only used to calculate and stream file headers. `pupynere-pdp 1.1.6` doesn't allocate memory to store variable data during variable creation; instead memory is allocate on a just-in-time basis when the variable is written to.