### PR TITLE
fixfilter resetting leads to empty date strings

### DIFF
--- a/pdp/static/js/crmp_controls.js
+++ b/pdp/static/js/crmp_controls.js
@@ -128,6 +128,11 @@ function getResetButton(map) {
     $(reset_button).bind('click', function () {
         this.form.reset();
         filter_clear(map);
+        // This wipes the date filters so the call to dateChange gets an empty string and
+        //throws ugly errors that eventually leads to erroneous tile loading from WMS.
+        map.filters.date = date_filter('YYYY/MM/DD','YYYY/MM/DD');
+        $('#from-date')[0].value=map.filters.date.filters[0].value
+        $('#to-date')[0].value=map.filters.date.filters[1].value
         dateChange(map);
         CRMPFilterChange(map);
         return false;

--- a/pdp/static/js/crmp_filters.js
+++ b/pdp/static/js/crmp_filters.js
@@ -15,10 +15,10 @@ function net_filter(net_name) {
 
 function date_filter(sdate, edate) {
     var d = new Date();
-    if (edate === 'YYYY/MM/DD') {
+    if (edate === 'YYYY/MM/DD' || edate === '') { //just in case still getting an empty string
         edate = d.getFullYear() + '/' + (d.getMonth() + 1) + '/' + d.getDate(); //today
     }
-    if (sdate === 'YYYY/MM/DD') {
+    if (sdate === 'YYYY/MM/DD' || sdate === '') { //here as well
         sdate = '1870/01/01'; // ~beginning of our data (unless we find a magic data set)
     }
     // http://stackoverflow.com/questions/325933/determine-whether-two-date-ranges-overlap
@@ -27,12 +27,12 @@ function date_filter(sdate, edate) {
         filters: [
             new OpenLayers.Filter.Comparison({
                 type: ">=",
-                property: "max_obs_time",
+                property: "min_obs_time", //this was wrong in previous version, the sdate in the min obs time.
                 value: sdate
             }),
             new OpenLayers.Filter.Comparison({
                 type: "<=",
-                property: "min_obs_time",
+                property: "max_obs_time", //this was wrong in previous version, the edate in the max obs time.
                 value: edate
             })
         ]


### PR DESCRIPTION
Patch to fix an issue where filter resetting leads to empty date strings that throw date errors in the UI and cause the WMS to fail.

Fixes #147 

Signed-off-by: Faron Anslow <fanslow@uvic.ca>