### PR TITLE
Format map timestamp on Gridded Observations panel

### DIFF
--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -32,7 +32,7 @@ function init_obs_map() {
         numcolorbands: 254,
         version: '1.1.1',
         srs: "EPSG:4326",
-        TIME: "1997-3-17T00:00:00Z",
+        TIME: "1997-03-17T00:00:00Z",
     };
 
     datalayerName = "Climate raster";


### PR DESCRIPTION
The map configuration date parameter was `1997-3-17T00:00:00Z`, which was unparsable by `Date()` and led to the date in the map legend appearing as `NaN/NaN/NaN`. Correct Date parameter to `1997-03-17T00:00:00Z`.

![maplegend](https://user-images.githubusercontent.com/4512605/72916228-83424080-3cf6-11ea-8d32-13475d1a806b.png)
