### PR TITLE
Use getScanName library step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node {
         publishDockerImage(image, 'PCIC_DOCKERHUB_CREDS')
     }
 
-    if(!BRANCH_NAME.contains('PR')) {
+    if(!BRANCH_NAME.contains('PR') || BRANCH_NAME == 'master') {
         stage('Security Scan') {
             writeFile file: 'anchore_images', text: getScanName(imageSuffix)
             anchore name: 'anchore_images', engineRetries: '700'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,18 +31,19 @@ node {
 
     def image
     def imageName
+    def imageSuffix = 'pdp'
 
     stage('Build Image') {
-        (image, imageName) = buildDockerImage('pdp')
+        (image, imageName) = buildDockerImage(imageSuffix)
     }
 
     stage('Publish Image') {
         publishDockerImage(image, 'PCIC_DOCKERHUB_CREDS')
     }
 
-    if(BRANCH_NAME.contains('PR')) {
+    if(!BRANCH_NAME.contains('PR')) {
         stage('Security Scan') {
-            writeFile file: 'anchore_images', text: imageName
+            writeFile file: 'anchore_images', text: getScanName(imageSuffix)
             anchore name: 'anchore_images', engineRetries: '700'
         }
     }


### PR DESCRIPTION
The pipeline was not specifying a tag in the `imageName` so Anchore was just using the `latest` tag as it's scan target.  This was not the desired behaviour as we would want to scan the image that was just created.  This PR introduces the shared library pipeline step `getScanName` which returns the appropriate image name and tag to scan.