### PR TITLE
Use "Lite" BC basemap: Gridded Hydrologic Model portal

### DIFF
--- a/docker/local-run/docker-compose.yaml
+++ b/docker/local-run/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
       - TILECACHE_URL=https://a.tile.pacificclimate.org/tilecache/tilecache.py https://b.tile.pacificclimate.org/tilecache/tilecache.py https://c.tile.pacificclimate.org/tilecache/tilecache.py
+      - BC_BASEMAP_URL=http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png
     entrypoint: /codebase/docker/local-run/entrypoint-fe.sh
     volumes:
       # This is to enable installing local versions of other packages from

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,6 +56,7 @@ They are loaded from the environment variables of the same name, upper cased.
 | `ncwms_url` | Raster portal ncWMS 2.x -- modelmeta translator URL. |
 | `old_ncwms_url` | Raster portal pure ncWMS 1.x URL. Used to fill in missing services from ncWMS 2.x. |
 | `tilecache_url` | Tileserver URLs (space separated list) for base maps |
+| `bc_basemap_url` | Tile server URLs  (space separated list) for BC base maps
 | `use_analytics` | Enable or disable Google Analytics reporting |
 | `analytics` | Google Analytics ID |
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,12 +66,13 @@ production environment. The infrastructure is in `docker/local-test/`.
 
 1. **Start the test container**
 
-    ```
-    docker-compose -f ./docker/local-test/docker-compose.yaml run --rm local-test 
-    ```
+   ```
+   docker-compose -f ./docker/local-test/docker-compose.yaml run --rm local-test 
+   ```
     
-    This starts the container, installs the local codebase, gives you a 
-    bash shell. You should see a standard bash prompt.
+   This starts the container, installs the local codebase (which may 
+   take over a minute), and gives 
+   you a bash shell. You should see a standard bash prompt.
 
 1. **Change code and run tests**
 
@@ -82,8 +83,8 @@ production environment. The infrastructure is in `docker/local-test/`.
     pytest -v -m "not local_only" --tb=short tests -x
     ```
     
-    *Do not stop the container until you have finished all changes and
-    testing you wish to make for a given session.* 
+    **Do not stop the container until you have finished all changes and
+    testing you wish to make for a given session.** 
     It is far more time efficient run tests inside the same container 
     (avoiding startup time) than to restart the container for each test.
     

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -42,6 +42,7 @@ def get_config_from_environment():
             'http://a.tiles.pacificclimate.org/tilecache/tilecache.py'
             ' http://b.tiles.pacificclimate.org/tilecache/tilecache.py'
             ' http://c.tiles.pacificclimate.org/tilecache/tilecache.py',
+        'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production
     }

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -12,6 +12,7 @@ GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
 TILECACHE_URL="http://a.tiles.pacificclimate.org/tilecache/tilecache.py http://b.tiles.pacificclimate.org/tilecache/tilecache.py http://c.tiles.pacificclimate.org/tilecache/tilecache.py"
+BC_BASEMAP_URL=http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png
 USE_ANALYTICS=True
 # change for production
 ANALYTICS=UA-20166041-3

--- a/pdp/static/js/__test__/app-test-helpers.js
+++ b/pdp/static/js/__test__/app-test-helpers.js
@@ -11,7 +11,8 @@ function initializeGlobals() {
         tilecache_url: [
             'tilecache_url'
         ],
-        ensemble_name: 'ensemble_name'
+        'bc_basemap_url': 'bc_basemap_url',
+        ensemble_name: 'ensemble_name',
     };
 }
 

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -385,6 +385,7 @@ condExport(module, {
     getNaBaseLayer: getNaBaseLayer,
     getTileBaseLayer: getTileBaseLayer,
     getBC3005OsmBaseLayer: getBC3005OsmBaseLayer,
+    getBC3005BCLiteBaseLayer: getBC3005BCLiteBaseLayer,
     getBasicControls: getBasicControls,
     getEditingToolbar: getEditingToolbar,
     getHandNav: getHandNav,

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -195,6 +195,21 @@ function getBC3005OsmBaseLayer(wmsurl, displayname, layername) {
     );
 }
 
+function getBC3005BCLiteBaseLayer(url, displayname) {
+  return new OpenLayers.Layer.XYZ(
+    displayname,
+    url,
+    {
+      projection: getProjection(3005),
+      units: 'Meter',
+      maxExtent: new OpenLayers.Bounds(-20037508, -20037508, 20037508, 20037508),
+      maxResolution: 156543.03125,
+      numZoomLevels: 14,
+      attribution: '© OpenStreetMap contributors'
+    }
+  );
+}
+
 function getBasicControls() {
     return [
         new OpenLayers.Control.LayerSwitcher({'ascending': false}),

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -112,7 +112,7 @@ function init_prism_map(config) {
         [
             ncwms,
             selectionLayer,
-            getBC3005OsmBaseLayer(pdp.tilecache_url, 'BC OpenStreetMap', 'bc_osm')
+            getBC3005BCLiteBaseLayer(pdp.tilecache_url, 'BC OSM Lite'),
         ]
     );
 

--- a/pdp/static/js/prism_demo_map.js
+++ b/pdp/static/js/prism_demo_map.js
@@ -112,7 +112,7 @@ function init_prism_map(config) {
         [
             ncwms,
             selectionLayer,
-            getBC3005BCLiteBaseLayer(pdp.tilecache_url, 'BC OSM Lite'),
+            getBC3005BCLiteBaseLayer(pdp.bc_basemap_url, 'BC OSM Lite'),
         ]
     );
 

--- a/pdp/static/js/vic_map.js
+++ b/pdp/static/js/vic_map.js
@@ -66,7 +66,7 @@ function init_vic_map(archive_portal) {
         [
             ncwms,
             selectionLayer,
-            getBC3005OsmBaseLayer(pdp.tilecache_url, 'BC OpenStreeMap', 'bc_osm')
+            getBC3005BCLiteBaseLayer(pdp.bc_basemap_url, 'BC OSM Lite'),
         ]
     );
 

--- a/pdp/templates/map.html
+++ b/pdp/templates/map.html
@@ -25,6 +25,7 @@
           ncwms_url: '${ncwms_url}',
           old_ncwms_url: '${old_ncwms_url}',
           tilecache_url: tcUrls,
+          bc_basemap_url: '${bc_basemap_url}',
           ensemble_name: '${ensemble_name}'
         };
 


### PR DESCRIPTION
## Changes
Use an OpenLayers `XYZ` layer pointed at new BC Lite basemap tiles

Resolves #246

## Checklist
- [ ] Full integration tests are passing locally
- [ ] Docs have been updated to reflect the changes