### PR TITLE
Create a new portal for downscaled CMIP6 data

### DIFF
--- a/pdp/main.py
+++ b/pdp/main.py
@@ -18,6 +18,7 @@ import portals.bc_prism as bc_prism
 import portals.downscale_archive as downscale_archive
 import portals.bccaq2_downscale as bccaq2
 import portals.bccaq2_cmip6 as bccaq2_cmip6
+import portals.bccaq2_canesm5 as bccaq2_canesm5
 import portals.bccaq_extremes as bccaq_extremes
 import portals.gridded_observations as gridded_observations
 import portals.vic_gen1 as vic_gen1
@@ -26,7 +27,8 @@ import portals.vic_gen2 as vic_gen2
 
 apps = (bc_prism, downscale_archive, bccaq2, vic_gen1, vic_gen2,
         gridded_observations, bccaq_extremes, pcds,
-        hydro_stn_archive, hydro_stn_cmip5, bccaq2_cmip6)
+        hydro_stn_archive, hydro_stn_cmip5, bccaq2_cmip6,
+        bccaq2_canesm5)
 
 
 def initialize_frontend(global_config, use_analytics=False):

--- a/pdp/main.py
+++ b/pdp/main.py
@@ -17,6 +17,7 @@ import portals.hydro_stn_cmip5 as hydro_stn_cmip5
 import portals.bc_prism as bc_prism
 import portals.downscale_archive as downscale_archive
 import portals.bccaq2_downscale as bccaq2
+import portals.bccaq2_cmip6 as bccaq2_cmip6
 import portals.bccaq_extremes as bccaq_extremes
 import portals.gridded_observations as gridded_observations
 import portals.vic_gen1 as vic_gen1
@@ -25,7 +26,7 @@ import portals.vic_gen2 as vic_gen2
 
 apps = (bc_prism, downscale_archive, bccaq2, vic_gen1, vic_gen2,
         gridded_observations, bccaq_extremes, pcds,
-        hydro_stn_archive, hydro_stn_cmip5)
+        hydro_stn_archive, hydro_stn_cmip5, bccaq2_cmip6)
 
 
 def initialize_frontend(global_config, use_analytics=False):

--- a/pdp/portals/bccaq2_canesm5.py
+++ b/pdp/portals/bccaq2_canesm5.py
@@ -1,0 +1,28 @@
+'''This portal serves an ensemble of several CanESM5 runs
+downscaled by BCCAQv2 for all Canada. As these are CMIP6
+datasets, the presentation is congruent with the rest of the
+CMIP6 datasets served by bccaq2_cmip6.py, including using
+the same ensemble lister.
+'''
+from pdp.portals import make_raster_frontend, data_server
+from pdp_util.ensemble_members import EnsembleMemberLister
+from pdp.portals.bccaq2_cmip6 import CMIP6EnsembleLister
+import re
+
+
+__all__ = ['url_base', 'mk_frontend', 'mk_backend']
+
+
+ensemble_name = 'bccaq2_canesm5'
+url_base = '/downscaled_canesm5'
+title = 'Statistically Downscaled GCM Scenarios - CanESM5'
+
+def mk_frontend(config):
+    return make_raster_frontend(config, ensemble_name, url_base,
+                                title, CMIP6EnsembleLister,
+                                 ['js/canada_ex_map.js',
+                                 'js/canesm5_app.js'])
+ 
+
+def mk_backend(config):
+    return data_server(config, ensemble_name)

--- a/pdp/portals/bccaq2_canesm5.py
+++ b/pdp/portals/bccaq2_canesm5.py
@@ -15,7 +15,7 @@ __all__ = ['url_base', 'mk_frontend', 'mk_backend']
 
 ensemble_name = 'bccaq2_canesm5'
 url_base = '/downscaled_canesm5'
-title = 'Statistically Downscaled GCM Scenarios - CanESM5'
+title = 'Canadian Downscaled Climate Scenarios - Univariate (CMIP6): CanDCS-U6'
 
 def mk_frontend(config):
     return make_raster_frontend(config, ensemble_name, url_base,

--- a/pdp/portals/bccaq2_cmip6.py
+++ b/pdp/portals/bccaq2_cmip6.py
@@ -13,7 +13,7 @@ __all__ = ['url_base', 'mk_frontend', 'mk_backend']
 
 ensemble_name = 'bccaq2_cmip6'
 url_base = '/downscaled_cmip6'
-title = 'Statistically Downscaled GCM Scenarios - CMIP6'
+title = 'Canadian Downscaled Climate Scenarios - Univariate (CMIP6): CanDCS-U6'
 
 
 class CMIP6EnsembleLister(EnsembleMemberLister):

--- a/pdp/portals/bccaq2_cmip6.py
+++ b/pdp/portals/bccaq2_cmip6.py
@@ -1,0 +1,36 @@
+'''This portal serves the CMIP6 data downscaled by BCCAQv2
+for all Canada. The UI is similar to the CMIP5 BCCAQv2 data, and
+the use the same map component (canada_ex_map.js), but 
+different frontend controllers (cmip6_bccaq2_app.js).
+'''
+from pdp.portals import make_raster_frontend, data_server
+from pdp_util.ensemble_members import EnsembleMemberLister
+
+
+__all__ = ['url_base', 'mk_frontend', 'mk_backend']
+
+
+ensemble_name = 'bccaq2_cmip6'
+url_base = '/downscaled_cmip6'
+title = 'Statistically Downscaled GCM Scenarios - CMIP6'
+
+
+class CMIP6EnsembleLister(EnsembleMemberLister):
+    def list_stuff(self, ensemble):
+        for dfv in ensemble.data_file_variables:
+            yield dfv.file.run.emission.short_name,\
+                dfv.file.run.model.short_name,\
+                dfv.file.run.name,\
+                dfv.netcdf_variable_name,\
+                dfv.file.unique_id.replace('+', '-')
+
+
+def mk_frontend(config):
+    return make_raster_frontend(config, ensemble_name, url_base,
+                                title, CMIP6EnsembleLister,
+                                 ['js/canada_ex_map.js',
+                                 'js/cmip6_bccaq2_app.js'])
+ 
+
+def mk_backend(config):
+    return data_server(config, ensemble_name)

--- a/pdp/portals/bccaq2_cmip6.py
+++ b/pdp/portals/bccaq2_cmip6.py
@@ -5,6 +5,7 @@ different frontend controllers (cmip6_bccaq2_app.js).
 '''
 from pdp.portals import make_raster_frontend, data_server
 from pdp_util.ensemble_members import EnsembleMemberLister
+import re
 
 
 __all__ = ['url_base', 'mk_frontend', 'mk_backend']
@@ -17,12 +18,27 @@ title = 'Statistically Downscaled GCM Scenarios - CMIP6'
 
 class CMIP6EnsembleLister(EnsembleMemberLister):
     def list_stuff(self, ensemble):
+        def format_scenario(scenario):
+            '''takes a scenario of the form "historical,ssp126" and
+            formats it to be "Historical, SSP1-2.6" or similar. 
+            unmatchable scenario strings are returned unchanged.'''
+            parsed = re.match(r"^historical,ssp(\d)(\d)(\d)$", scenario)
+            if parsed:
+                return "Historical, SSP{}-{}.{}".format(parsed.group(1), 
+                                                parsed.group(2),
+                                                parsed.group(3))
+            else:
+                return scenario
+        
         for dfv in ensemble.data_file_variables:
-            yield dfv.file.run.emission.short_name,\
+            yield format_scenario(dfv.file.run.emission.short_name),\
                 dfv.file.run.model.short_name,\
                 dfv.file.run.name,\
                 dfv.netcdf_variable_name,\
                 dfv.file.unique_id.replace('+', '-')
+
+
+    
 
 
 def mk_frontend(config):

--- a/pdp/portals/bccaq2_downscale.py
+++ b/pdp/portals/bccaq2_downscale.py
@@ -12,7 +12,7 @@ __all__ = ['url_base', 'mk_frontend', 'mk_backend']
 
 ensemble_name = 'bccaq_version_2'
 url_base = '/downscaled_gcms'
-title = 'Statistically Downscaled GCM Scenarios - BCCAQv2'
+title = 'Canadian Downscaled Climate Scenarios – Univariate (CMIP5): CanDCS-U5'
 
 
 class BCCAQ2EnsembleLister(EnsembleMemberLister):

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -7,6 +7,7 @@
  *    * The BCSD and BCCAQv1 datasets (canada_ex_app.js)
  *    * The BCCAQv2 CMIP5 datasets (canada_ex_app.js)
  *    * The BCCAQv2 CMIP6 datasets (cmip6_bccaq2_app.js)
+ *    * The BCCAQv2 CanESM5 datasets (canesm5_app.js)
  * Each seperate app passes in a default dataset and timestamp
  * to initialize the map, but they have the same pallettes,
  * numerical and spatial extents.

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -2,9 +2,14 @@
 /*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNaBaseLayer, getOpacitySlider, Colorbar*/
 
 /*
- * This map displays both version 1 and version 2 of the BCCAQ / BCSD
- * data. The only difference is default dataset and timestamps, which
- * are passed in from the top level app.
+ * This map displays all-Canada pr, tasmin, and tasmax datasets.
+ * It is used by:
+ *    * The BCSD and BCCAQv1 datasets (canada_ex_app.js)
+ *    * The BCCAQv2 CMIP5 datasets (canada_ex_app.js)
+ *    * The BCCAQv2 CMIP6 datasets (cmip6_bccaq2_app.js)
+ * Each seperate app passes in a default dataset and timestamp
+ * to initialize the map, but they have the same pallettes,
+ * numerical and spatial extents.
  */
 (function () {
 

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -103,10 +103,12 @@
         function set_map_title(layer_name) {
             // 'this' must be bound to the ncwms layer object
             var d = new Date(this.params.TIME), date;
+            const monthNames = ["January", "February", "March", "April", "May", "June",
+                                "July", "August", "September", "October", "November", "December"]
             if (layer_name.match(/_yr_/)) { // is yearly
                 date = d.getFullYear();
             } else {
-                date = d.getFullYear() + '/' + (d.getMonth() + 1);
+                date = monthNames[d.getMonth()] + " " + d.getFullYear();
             }
             $('#map-title').html(layer_name + '<br />' + date);
 

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -68,7 +68,7 @@
             if (varname === 'pr') {
                 this.params.LOGSCALE = true;
                 this.params.STYLES = 'default/blueheat';
-                this.params.BELOWMINCOLOR = 'transparent';
+                this.params.BELOWMINCOLOR = 'extend';
                 this.params.COLORSCALERANGE = '1.0,30.0';
             } else {
                 this.params.LOGSCALE = false;

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -67,7 +67,7 @@
             if (varname === 'pr') {
                 this.params.LOGSCALE = true;
                 this.params.STYLES = 'default/blueheat';
-                this.params.BELOWMINCOLOR = 'transparent';
+                this.params.BELOWMINCOLOR = 'extend';
                 this.params.COLORSCALERANGE = '1.0,30.0';
             } else {
                 this.params.LOGSCALE = false;

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -67,7 +67,7 @@
             if (varname === 'pr') {
                 this.params.LOGSCALE = true;
                 this.params.STYLES = 'default/blueheat';
-                this.params.BELOWMINCOLOR = 'extend';
+                this.params.BELOWMINCOLOR = 'transparent';
                 this.params.COLORSCALERANGE = '1.0,30.0';
             } else {
                 this.params.LOGSCALE = false;

--- a/pdp/static/js/canesm5_app.js
+++ b/pdp/static/js/canesm5_app.js
@@ -1,0 +1,107 @@
+/*jslint browser: true, devel: true */
+/*global $, jQuery, OpenLayers, pdp, map, init_raster_map,
+processNcwmsLayerMetadata, getRasterControls, getRasterDownloadOptions,
+RasterDownloadLink, MetadataDownloadLink*/
+
+/*
+ * This front end displays the CanESM2 BCCAQ2 data.
+ *    backend: bccaq2_canesm5.py
+ *    url_base: downscaled_canesm5
+ *    ensemble: bccaq2_canesm5
+ *    map: canada_ex_map.js
+ * This portal is identical to the CMIP6 BCCAQ2 portal, except for the
+ * available data. It displays a collection of downscaled CanESM5 CMIP6
+ * runs, instead of multiple models.
+ */
+
+(function ($) {
+    "use strict";
+
+    function canesm5_app() {
+        var map, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog,
+            dlLink, mdLink, capabilities_request, ncwms_capabilities;
+
+        map = init_raster_map({
+            variable: "tasmin",
+            dataset: "tasmin_day_BCCAQv2_CanESM5_historical-ssp126_r1iippff_19500101-21001231_Canada",
+            timestamp: "2000-01-01"
+        });
+        
+        ncwmsLayer = map.getClimateLayer();
+        selectionLayer = map.getSelectionLayer();
+
+        catalog_request = dataServices.getCatalog();
+
+        capabilities_request = dataServices.getNCWMSLayerCapabilities(ncwmsLayer);
+
+        document.getElementById("pdp-controls")
+            .appendChild(getRasterControls(pdp.ensemble_name));
+        document.getElementById("pdp-controls")
+            .appendChild(getRasterDownloadOptions('first', 'last'));
+
+        // Data Download Link
+        dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'tasmax', '0:55152', '0:510', '0:1068');
+        $('#data-format-selector').change(
+            function (evt) {
+                dlLink.onExtensionChange($(this).val());
+            }
+        );
+
+        ncwmsLayer.events.register('change', dlLink, function () {
+            processNcwmsLayerMetadata(ncwmsLayer, catalog);
+            capabilities_request = dataServices.getNCWMSLayerCapabilities(ncwmsLayer);
+            capabilities_request.done(function(data) {
+                ncwms_capabilities = data;
+                if (selectionLayer.features.length > 0) {
+                    dlLink.onBoxChange({feature: selectionLayer.features[0]}, ncwms_capabilities);
+                }
+            });
+        });
+        ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
+
+        selectionLayer.events.register('featureadded', dlLink, function (selection){
+            capabilities_request.done(function(data) {
+                ncwms_capabilities = data;
+                dlLink.onBoxChange(selection, data);
+            });
+        });
+
+        dlLink.register($('#download-timeseries'), function (node) {
+                node.attr('href', dlLink.getUrl());
+            }
+        );
+        dlLink.trigger();
+
+        // Metadata/Attributes Download Link
+        mdLink = new MetadataDownloadLink($('#download-metadata'), ncwmsLayer, undefined);
+        ncwmsLayer.events.register('change', mdLink, mdLink.onLayerChange);
+        mdLink.register($('#download-metadata'), function (node) {
+                node.attr('href', mdLink.getUrl());
+            }
+        );
+        mdLink.trigger();
+
+        // Date picker event for both links
+        $("[class^='datepicker']").change(
+            function (evt) {
+                dlLink.onTimeChange();
+            }
+        );
+
+        capabilities_request.done(function (data) {
+            ncwms_capabilities = data;
+        });
+        catalog_request.done(function (data) {
+            catalog = dlLink.catalog = mdLink.catalog = data;
+            processNcwmsLayerMetadata(ncwmsLayer, catalog);
+            // Set the data URL as soon as it is available
+            dlLink.onLayerChange();
+            mdLink.onLayerChange();
+        });
+
+    }
+
+    condExport(module, canesm5_app, 'canesm5_app');
+
+    $(document).ready(canesm5_app);
+})(jQuery);

--- a/pdp/static/js/cmip6_bccaq2_app.js
+++ b/pdp/static/js/cmip6_bccaq2_app.js
@@ -1,0 +1,106 @@
+/*jslint browser: true, devel: true */
+/*global $, jQuery, OpenLayers, pdp, map, init_raster_map,
+processNcwmsLayerMetadata, getRasterControls, getRasterDownloadOptions,
+RasterDownloadLink, MetadataDownloadLink*/
+
+/*
+ * This front end displays the CMIP6 BCCAQ2 data.
+ *    backend: bccaq2_cmip6.py
+ *    url_base: downscaled_cmip6
+ *    ensemble: bccaq2_cmip6
+ *    map: canada_ex_map.js
+ * Shares a lot of boilerplate with canada_ex_app.js, the CMIP5 BCCAQ2 
+ * displaying app.
+ */
+
+(function ($) {
+    "use strict";
+
+    function cmip6_bccaq2_app() {
+        var map, ncwmsLayer, selectionLayer, catalogUrl, catalog_request, catalog,
+            dlLink, mdLink, capabilities_request, ncwms_capabilities;
+
+        map = init_raster_map({
+            variable: "tasmin",
+            dataset: "tasmin_day_BCCAQv2_CanESM5_historical-ssp126_r1iippff_19500101-21001231_Canada",
+            timestamp: "2000-01-01"
+        });
+        
+        ncwmsLayer = map.getClimateLayer();
+        selectionLayer = map.getSelectionLayer();
+
+        catalog_request = dataServices.getCatalog();
+
+        capabilities_request = dataServices.getNCWMSLayerCapabilities(ncwmsLayer);
+
+        document.getElementById("pdp-controls")
+            .appendChild(getRasterControls(pdp.ensemble_name));
+        document.getElementById("pdp-controls")
+            .appendChild(getRasterDownloadOptions('first', 'last'));
+
+        // Data Download Link
+        dlLink = new RasterDownloadLink($('#download-timeseries'), ncwmsLayer, undefined, 'nc', 'tasmax', '0:55152', '0:510', '0:1068');
+        $('#data-format-selector').change(
+            function (evt) {
+                dlLink.onExtensionChange($(this).val());
+            }
+        );
+
+        ncwmsLayer.events.register('change', dlLink, function () {
+            processNcwmsLayerMetadata(ncwmsLayer, catalog);
+            capabilities_request = dataServices.getNCWMSLayerCapabilities(ncwmsLayer);
+            capabilities_request.done(function(data) {
+                ncwms_capabilities = data;
+                if (selectionLayer.features.length > 0) {
+                    dlLink.onBoxChange({feature: selectionLayer.features[0]}, ncwms_capabilities);
+                }
+            });
+        });
+        ncwmsLayer.events.register('change', dlLink, dlLink.onLayerChange);
+
+        selectionLayer.events.register('featureadded', dlLink, function (selection){
+            capabilities_request.done(function(data) {
+                ncwms_capabilities = data;
+                dlLink.onBoxChange(selection, data);
+            });
+        });
+
+        dlLink.register($('#download-timeseries'), function (node) {
+                node.attr('href', dlLink.getUrl());
+            }
+        );
+        dlLink.trigger();
+
+        // Metadata/Attributes Download Link
+        mdLink = new MetadataDownloadLink($('#download-metadata'), ncwmsLayer, undefined);
+        ncwmsLayer.events.register('change', mdLink, mdLink.onLayerChange);
+        mdLink.register($('#download-metadata'), function (node) {
+                node.attr('href', mdLink.getUrl());
+            }
+        );
+        mdLink.trigger();
+
+        // Date picker event for both links
+        $("[class^='datepicker']").change(
+            function (evt) {
+                dlLink.onTimeChange();
+            }
+        );
+
+        capabilities_request.done(function (data) {
+            ncwms_capabilities = data;
+        });
+        catalog_request.done(function (data) {
+            catalog = dlLink.catalog = mdLink.catalog = data;
+            processNcwmsLayerMetadata(ncwmsLayer, catalog);
+            // Set the data URL as soon as it is available
+            dlLink.onLayerChange();
+            mdLink.onLayerChange();
+        });
+
+    }
+
+    condExport(module, cmip6_bccaq2_app, 'cmip6_bccaq2_app');
+
+    $(document).ready(cmip6_bccaq2_app);
+})(jQuery);

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -94,7 +94,7 @@ function init_obs_map() {
               min = 1;
               max = data.max;
               newParams["STYLES"] = "default/blueheat";
-              newParams["BELOWMINCOLOR"] = 'extend';
+              newParams["BELOWMINCOLOR"] = 'transparent';
             }
             else {
               newParams["LOGSCALE"] = "false";

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -94,7 +94,7 @@ function init_obs_map() {
               min = 1;
               max = data.max;
               newParams["STYLES"] = "default/blueheat";
-              newParams["BELOWMINCOLOR"] = 'transparent';
+              newParams["BELOWMINCOLOR"] = 'extend';
             }
             else {
               newParams["LOGSCALE"] = "false";

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -94,6 +94,7 @@ function init_obs_map() {
               min = 1;
               max = data.max;
               newParams["STYLES"] = "default/blueheat";
+              newParams["BELOWMINCOLOR"] = 'extend';
             }
             else {
               newParams["LOGSCALE"] = "false";


### PR DESCRIPTION
This PR creates a new web portal so users can view and download CMIP6 datasets that have been downscaled with BCCAQ2. The portal is extremely similar to the Downscaled GCMS portal, where users can view and download CMIP5 BCCAQ2 datasets; they use the same all-Canada map component.

This PR also includes a minor update to the mapping code to take advantage of the updated ncWMS. Previously, with ncWMS 1, we could not use the `BELOWMINCOLOR` parameter to specify what colour zero precipitation should be rendered as when colours were assigned with a logarithmic scale. Now that @rod-glover has updated the PDP to use ncWMS 2, we are able to use this parameter to generate logscaled precipitation maps with no colour discontinuity.

Demo coming.

resolves #250 
resolves #252 