### PR TITLE
Remove mdash

### DIFF
--- a/pdp/portals/bccaq2_downscale.py
+++ b/pdp/portals/bccaq2_downscale.py
@@ -12,7 +12,7 @@ __all__ = ['url_base', 'mk_frontend', 'mk_backend']
 
 ensemble_name = 'bccaq_version_2'
 url_base = '/downscaled_gcms'
-title = 'Canadian Downscaled Climate Scenarios – Univariate (CMIP5): CanDCS-U5'
+title = 'Canadian Downscaled Climate Scenarios - Univariate (CMIP5): CanDCS-U5'
 
 
 class BCCAQ2EnsembleLister(EnsembleMemberLister):

--- a/pdp/static/js/cmip6_bccaq2_app.js
+++ b/pdp/static/js/cmip6_bccaq2_app.js
@@ -22,7 +22,7 @@ RasterDownloadLink, MetadataDownloadLink*/
 
         map = init_raster_map({
             variable: "tasmin",
-            dataset: "tasmin_day_BCCAQv2_CanESM5_historical-ssp126_r1iippff_19500101-21001231_Canada",
+            dataset: "tasmin_day_BCCAQv2_CanESM5_historical-ssp126_r1i1p2f1_19500101-21001231_Canada",
             timestamp: "2000-01-01"
         });
         


### PR DESCRIPTION
Removes an mdash I'd accidentally added to a page title somehow, most likely by cutting and pasting the titles from a document or email I was sent.

Resolves #260 