### PR TITLE
Add pcic12 headings

### DIFF
--- a/pdp/portals/bccaq2_cmip6.py
+++ b/pdp/portals/bccaq2_cmip6.py
@@ -18,19 +18,34 @@ title = 'Canadian Downscaled Climate Scenarios - Univariate (CMIP6): CanDCS-U6'
 
 class CMIP6EnsembleLister(EnsembleMemberLister):
     def list_stuff(self, ensemble):
-        def format_scenario(scenario):
+        def format_scenario(scenario, pcic12=False):
             '''takes a scenario of the form "historical,ssp126" and
             formats it to be "Historical, SSP1-2.6" or similar. 
             unmatchable scenario strings are returned unchanged.'''
             parsed = re.match(r"^historical,ssp(\d)(\d)(\d)$", scenario)
             if parsed:
-                return "Historical, SSP{}-{}.{}".format(parsed.group(1), 
+                scenario = "Historical, SSP{}-{}.{}".format(parsed.group(1), 
                                                 parsed.group(2),
                                                 parsed.group(3))
+                if pcic12:
+                    scenario += " (PCIC12)"
+                return scenario
             else:
                 return scenario
         
+        pcic_12 = ["BCC-CSM2-MR", "CMCC-ESM2", "EC-Earth3-Veg", "FGOALS-g3",\
+	        "INM-CM5-0", "IPSL-CM6A-LR", "MIROC-ES2L", "MPI-ESM1-2-HR",\
+        	"MRI-ESM2-0", "NorESM2-LM", "TaiESM1", "UKESM1-0-LL"]
         for dfv in ensemble.data_file_variables:
+            if dfv.file.run.model.short_name in pcic_12:
+                scenario = format_scenario(dfv.file.run.emission.short_name, pcic12=True)
+                yield scenario,\
+                    dfv.file.run.model.short_name,\
+                    dfv.file.run.name,\
+                    dfv.netcdf_variable_name,\
+                    dfv.file.unique_id.replace('+', '-')
+
+            # Display all models in general headings
             yield format_scenario(dfv.file.run.emission.short_name),\
                 dfv.file.run.model.short_name,\
                 dfv.file.run.name,\

--- a/pdp/portals/bccaq2_cmip6.py
+++ b/pdp/portals/bccaq2_cmip6.py
@@ -1,7 +1,8 @@
 '''This portal serves the CMIP6 data downscaled by BCCAQv2
 for all Canada. The UI is similar to the CMIP5 BCCAQv2 data, and
 the use the same map component (canada_ex_map.js), but 
-different frontend controllers (cmip6_bccaq2_app.js).
+different frontend controllers (cmip6_bccaq2_app.js). It also contains
+additional headings for the PCIC12 models.
 '''
 from pdp.portals import make_raster_frontend, data_server
 from pdp_util.ensemble_members import EnsembleMemberLister

--- a/pdp/portals/bccaq2_cmip6.py
+++ b/pdp/portals/bccaq2_cmip6.py
@@ -34,24 +34,24 @@ class CMIP6EnsembleLister(EnsembleMemberLister):
             else:
                 return scenario
         
-        pcic_12 = ["BCC-CSM2-MR", "CMCC-ESM2", "EC-Earth3-Veg", "FGOALS-g3",\
-	        "INM-CM5-0", "IPSL-CM6A-LR", "MIROC-ES2L", "MPI-ESM1-2-HR",\
+        pcic_12 = ["BCC-CSM2-MR", "CMCC-ESM2", "EC-Earth3-Veg", "FGOALS-g3",
+	        "INM-CM5-0", "IPSL-CM6A-LR", "MIROC-ES2L", "MPI-ESM1-2-HR",
         	"MRI-ESM2-0", "NorESM2-LM", "TaiESM1", "UKESM1-0-LL"]
         for dfv in ensemble.data_file_variables:
             if dfv.file.run.model.short_name in pcic_12:
                 scenario = format_scenario(dfv.file.run.emission.short_name, pcic12=True)
-                yield scenario,\
-                    dfv.file.run.model.short_name,\
-                    dfv.file.run.name,\
-                    dfv.netcdf_variable_name,\
-                    dfv.file.unique_id.replace('+', '-')
+                yield (scenario,
+                    dfv.file.run.model.short_name,
+                    dfv.file.run.name,
+                    dfv.netcdf_variable_name,
+                    dfv.file.unique_id.replace('+', '-'))
 
             # Display all models in general headings
-            yield format_scenario(dfv.file.run.emission.short_name),\
-                dfv.file.run.model.short_name,\
-                dfv.file.run.name,\
-                dfv.netcdf_variable_name,\
-                dfv.file.unique_id.replace('+', '-')
+            yield (format_scenario(dfv.file.run.emission.short_name),
+                dfv.file.run.model.short_name,
+                dfv.file.run.name,
+                dfv.netcdf_variable_name,
+                dfv.file.unique_id.replace('+', '-'))
 
 
     

--- a/pdp/portals/bccaq2_downscale.py
+++ b/pdp/portals/bccaq2_downscale.py
@@ -16,11 +16,11 @@ title = 'Canadian Downscaled Climate Scenarios - Univariate (CMIP5): CanDCS-U5'
 class BCCAQ2EnsembleLister(EnsembleMemberLister):
     def list_stuff(self, ensemble):
         for dfv in ensemble.data_file_variables:
-            yield dfv.file.run.emission.short_name,\
-                dfv.file.run.model.short_name,\
-                dfv.file.run.name,\
-                dfv.netcdf_variable_name,\
-                dfv.file.unique_id.replace('+', '-')
+            yield (dfv.file.run.emission.short_name,
+                dfv.file.run.model.short_name,
+                dfv.file.run.name,
+                dfv.netcdf_variable_name,
+                dfv.file.unique_id.replace('+', '-'))
 
 
 def mk_frontend(config):

--- a/pdp/portals/mbcn_cmip6.py
+++ b/pdp/portals/mbcn_cmip6.py
@@ -33,24 +33,24 @@ class CMIP6EnsembleLister(EnsembleMemberLister):
             else:
                 return scenario
         
-        pcic_12 = ["BCC-CSM2-MR", "CMCC-ESM2", "EC-Earth3-Veg", "FGOALS-g3",\
-	        "INM-CM5-0", "IPSL-CM6A-LR", "MIROC-ES2L", "MPI-ESM1-2-HR",\
+        pcic_12 = ["BCC-CSM2-MR", "CMCC-ESM2", "EC-Earth3-Veg", "FGOALS-g3",
+	        "INM-CM5-0", "IPSL-CM6A-LR", "MIROC-ES2L", "MPI-ESM1-2-HR",
         	"MRI-ESM2-0", "NorESM2-LM", "TaiESM1", "UKESM1-0-LL"]
         for dfv in ensemble.data_file_variables:
             if dfv.file.run.model.short_name in pcic_12:
                 scenario = format_scenario(dfv.file.run.emission.short_name, pcic12=True)
-                yield scenario,\
-                    dfv.file.run.model.short_name,\
-                    dfv.file.run.name,\
-                    dfv.netcdf_variable_name,\
-                    dfv.file.unique_id.replace('+', '-')
+                yield (scenario,
+                    dfv.file.run.model.short_name,
+                    dfv.file.run.name,
+                    dfv.netcdf_variable_name,
+                    dfv.file.unique_id.replace('+', '-'))
 
             # Display all models in general headings
-            yield format_scenario(dfv.file.run.emission.short_name),\
-                dfv.file.run.model.short_name,\
-                dfv.file.run.name,\
-                dfv.netcdf_variable_name,\
-                dfv.file.unique_id.replace('+', '-')
+            yield (format_scenario(dfv.file.run.emission.short_name),
+                dfv.file.run.model.short_name,
+                dfv.file.run.name,
+                dfv.netcdf_variable_name,
+                dfv.file.unique_id.replace('+', '-'))
 
 
     

--- a/pdp/portals/mbcn_cmip6.py
+++ b/pdp/portals/mbcn_cmip6.py
@@ -1,8 +1,7 @@
 '''This portal serves the CMIP6 data downscaled by MBCn
 for all Canada. The UI is similar to the CMIP6 BCCAQv2 data, and
 the use the same map component (canada_ex_map.js), but
-different frontend controllers (cmip6_mbcn_app.js). This also has the
-PCIC12 models listed under their own headings.
+different frontend controllers (cmip6_mbcn_app.js).
 '''
 from pdp.portals import make_raster_frontend, data_server
 from pdp_util.ensemble_members import EnsembleMemberLister

--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -181,22 +181,29 @@ function generateMenuTree(subtree, leafNameMapping, pcic12 = false) {
             leafNameMapping[b] : b).toLowerCase();
         return adn.localeCompare(bdn);
     }
-    if (pcic12) { // Arrange PCIC12 models in specific order
+
+    // display PCIC12 models in specific order
+    function generatePCIC12Subtree() {
         const models = ["BCC-CSM2-MR", "NorESM2-LM", "MIROC-ES2L",
         "MPI-ESM1-2-HR", "MRI-ESM2-0", "UKESM1-0-LL", "EC-Earth3-Veg",
         "CMCC-ESM2", "INM-CM5-0", "FGOALS-g3", "TaiESM1", "IPSL-CM6A-LR"];
         models.forEach((model) => {
             var li = $('<li/>');
-            li.append($('<a/>').text(model))
+            li
+            .append($('<a/>').text(model))
             .append(generateMenuTree(subtree[model], leafNameMapping));
             li.appendTo(ul);
         });
-    } else {
+    }
+
+    // display other headings in alphabetical order
+    function generateGeneralSubtree() {
         $.each(Object.keys(subtree).sort(compareDisplayName), function (index, stuff) {
             var newlayer, linkText,
                 li = $('<li/>');
             if (subtree[stuff] instanceof Object) {
-                li.append($('<a/>').text(stuff))
+                li
+                .append($('<a/>').text(stuff))
                 .append(generateMenuTree(subtree[stuff], leafNameMapping, stuff.includes("PCIC12")));
             } else {
                 newlayer = subtree[stuff] + "/" + stuff;
@@ -212,6 +219,12 @@ function generateMenuTree(subtree, leafNameMapping, pcic12 = false) {
             }
             li.appendTo(ul);
         });
+    }
+
+    if (pcic12) {
+        generatePCIC12Subtree();
+    } else {
+        generateGeneralSubtree();
     }
     /*jslint unparam: false*/
     return ul;

--- a/pdp/static/js/pdp_controls.js
+++ b/pdp/static/js/pdp_controls.js
@@ -187,7 +187,8 @@ function generateMenuTree(subtree, leafNameMapping, pcic12 = false) {
         "CMCC-ESM2", "INM-CM5-0", "FGOALS-g3", "TaiESM1", "IPSL-CM6A-LR"];
         models.forEach((model) => {
             var li = $('<li/>');
-            li.append($('<a/>').text(model)).append(generateMenuTree(subtree[model], leafNameMapping));
+            li.append($('<a/>').text(model))
+            .append(generateMenuTree(subtree[model], leafNameMapping));
             li.appendTo(ul);
         });
     } else {
@@ -195,11 +196,8 @@ function generateMenuTree(subtree, leafNameMapping, pcic12 = false) {
             var newlayer, linkText,
                 li = $('<li/>');
             if (subtree[stuff] instanceof Object) {
-                if (stuff.includes("PCIC12")) {
-                    li.append($('<a/>').text(stuff)).append(generateMenuTree(subtree[stuff], leafNameMapping, true));
-                } else {
-                    li.append($('<a/>').text(stuff)).append(generateMenuTree(subtree[stuff], leafNameMapping));
-                }
+                li.append($('<a/>').text(stuff))
+                .append(generateMenuTree(subtree[stuff], leafNameMapping, stuff.includes("PCIC12")));
             } else {
                 newlayer = subtree[stuff] + "/" + stuff;
                 linkText = stuff;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -340,6 +340,10 @@ def test_climatology_bounds(pcic_data_portal):
 @pytest.mark.parametrize(('portal', 'ensemble'), [
         ('bc_prism', 'bc_prism'),
         ('downscaled_gcms', 'bccaq_version_2'),
+        ('downscaled_cmip6', 'bccaq2_cmip6'),
+        ('downscaled_canesm5', 'bccaq2_canesm5'),
+        ('downscaled_cmip6_multi', 'mbcn_cmip6'),
+        ('downscaled_canesm5_multi', 'mbcn_canesm5'),
         ('hydro_model_archive', 'vic_gen1'),
         ('gridded_observations', 'gridded-obs-met-data')
     ])


### PR DESCRIPTION
## Changes
This PR adds headings to the [`downscaled_cmip6` page](https://services.pacificclimate.org/dev/portal/downscaled_cmip6/map/) to display the PCIC12 models identically to the [`downscaled_cmip6_multi` page](https://services.pacificclimate.org/dev/portal/downscaled_cmip6_multi/map/). It also rearranges the order in which these models are displayed as requested by RCI.


Resolves #295 

## Checklist
- [x] Full integration tests are passing locally
- [x] Docs have been updated to reflect the changes