### PR TITLE
I297 add pcic blend

### DIFF
--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -24,8 +24,9 @@ class GriddedObservationsEnsembleLister(EnsembleMemberLister):
 
         for dfv in sorted(ensemble.data_file_variables,
                           key=lambda dfv: dfv.netcdf_variable_name):
-            yield dataset_names[dfv.file.run.model.short_name],\
-                dfv.netcdf_variable_name, dfv.file.unique_id.replace('+', '-')
+            if dfv.file.run.model.short_name in dataset_names.keys(): # Avoid using datasets that have been associated with the ensemble but not yet used in dataset_names
+                yield dataset_names[dfv.file.run.model.short_name],\
+                    dfv.netcdf_variable_name, dfv.file.unique_id.replace('+', '-')
 
 
 def mk_frontend(config):

--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -8,7 +8,7 @@ from pdp_util.ensemble_members import EnsembleMemberLister
 __all__ = ['url_base', 'mk_frontend', 'mk_backend']
 
 
-ensemble_name = 'gridded-obs-met-data-test'
+ensemble_name = 'gridded-obs-met-data'
 url_base = '/gridded_observations'
 title = 'Daily Gridded Meteorological Datasets'
 

--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -24,7 +24,7 @@ class GriddedObservationsEnsembleLister(EnsembleMemberLister):
 
         for dfv in sorted(ensemble.data_file_variables,
                           key=lambda dfv: dfv.netcdf_variable_name):
-            if dfv.file.run.model.short_name in dataset_names.keys(): # Avoid using datasets that have been associated with the ensemble but not yet used in dataset_names
+            if dfv.file.run.model.short_name in dataset_names.keys(): # Avoid KeyError for datasets associated with ensemble but not yet part of dataset_names
                 yield dataset_names[dfv.file.run.model.short_name],\
                     dfv.netcdf_variable_name, dfv.file.unique_id.replace('+', '-')
 

--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -18,7 +18,6 @@ class GriddedObservationsEnsembleLister(EnsembleMemberLister):
     def list_stuff(self, ensemble):
         dataset_names = {
             "ANUSPLIN_CDA_v2012.1": "NRCANmet 2012",
-            "SYMAP_BC_v1": "PBCmet 2010",
             "TPS_NWNA_v1": "PNWNAmet 2015",
             "PCIC_BLEND_v1": "PCIC Blend 2021"}
 

--- a/pdp/portals/gridded_observations.py
+++ b/pdp/portals/gridded_observations.py
@@ -8,7 +8,7 @@ from pdp_util.ensemble_members import EnsembleMemberLister
 __all__ = ['url_base', 'mk_frontend', 'mk_backend']
 
 
-ensemble_name = 'gridded-obs-met-data'
+ensemble_name = 'gridded-obs-met-data-test'
 url_base = '/gridded_observations'
 title = 'Daily Gridded Meteorological Datasets'
 
@@ -19,7 +19,8 @@ class GriddedObservationsEnsembleLister(EnsembleMemberLister):
         dataset_names = {
             "ANUSPLIN_CDA_v2012.1": "NRCANmet 2012",
             "SYMAP_BC_v1": "PBCmet 2010",
-            "TPS_NWNA_v1": "PNWNAmet 2015"}
+            "TPS_NWNA_v1": "PNWNAmet 2015",
+            "PCIC_BLEND_v1": "PCIC Blend 2021"}
 
         for dfv in sorted(ensemble.data_file_variables,
                           key=lambda dfv: dfv.netcdf_variable_name):


### PR DESCRIPTION
This PR resolves #297 and removes the `PBCmet` data as requested by RCI. This also adds a check to make sure each `dfv.file.run.model.short_name` is part of the `dataset_names` dictionary to avoid a KeyError for datasets which have been associated with the `gridded-obs-met-data` ensemble but not added to this dictionary. This KeyError ended up happening with the production instances of the PDP when I initially associated the new data with that ensemble.

The `ensemble_name` is currently `gridded-obs-met-data-test`, which contains this new data but is not used in the production instances, and it will be changed to `gridded-obs-met-data` right before I merge. This means that I will be associating this data with the actual `gridded-obs-met-data` ensemble right after I deploy a new release.

The demo can be viewed [here](https://services.pacificclimate.org/dev/portal/gridded_observations/map/).