### PR TITLE
I298 tiles url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Passwords
+*password*

--- a/doc/source/raster.rst
+++ b/doc/source/raster.rst
@@ -162,7 +162,7 @@ A user with experience in programming or scripting should be able to reasonably 
 
 Map
 ^^^
-All mapping is provided using open geospatial protocols. Base maps may be requested using `Open Source Geospatial Foundation's (OSGeo) <http://www.osgeo.org>`_ `Tile Map Service Specification <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification>`_. We deploy our basemaps via Tilecache and they can be accessed at https://a.tile.pacificclimate.org/tilecache/tilecache.py.
+All mapping is provided using open geospatial protocols. Base maps may be requested using `Open Source Geospatial Foundation's (OSGeo) <http://www.osgeo.org>`_ `Tile Map Service Specification <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification>`_. We deploy our basemaps via `MapProxy <https://mapproxy.org/>`_ and they can be accessed at https://services.pacificclimate.org/mapproxy/service.
 
 Climate raster overlays are served via the `OSGeo's Open Geospatial Consortium's (OGC) <http://www.opengeospatial.org/>`_ `Web Mapping Service (WMS) protocol <http://www.opengeospatial.org/standards/wms>`_. To obtain the climate raster overlays, one may make a valid WMS request to our deployment of `ncWMS <http://www.resc.rdg.ac.uk/trac/ncWMS/>`_ located at https://tools.pacificclimate.org/ncWMS-PCIC.
 

--- a/docker/local-run/docker-compose.yaml
+++ b/docker/local-run/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILES_URL=https://services.pacificclimate.org/dev/tiles
+      - NA_TILES_URL=https://services.pacificclimate.org/dev/tiles/lite-wgs84
       # In order to pass environment variables with *content* of the form
       # `${...}` through to JavaScript, the `$` must be escaped as `$$`
       - BC_BASEMAP_URL=https://services.pacificclimate.org/dev/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/docker/local-run/docker-compose.yaml
+++ b/docker/local-run/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILECACHE_URL=https://a.tile.pacificclimate.org/tilecache/tilecache.py https://b.tile.pacificclimate.org/tilecache/tilecache.py https://c.tile.pacificclimate.org/tilecache/tilecache.py
+      - TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
       # In order to pass environment variables with *content* of the form
       # `${...}` through to JavaScript, the `$` must be escaped as `$$`
       - BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/docker/local-run/docker-compose.yaml
+++ b/docker/local-run/docker-compose.yaml
@@ -24,10 +24,10 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - WGS84_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - TILES_URL=https://services.pacificclimate.org/dev/tiles
       # In order to pass environment variables with *content* of the form
       # `${...}` through to JavaScript, the `$` must be escaped as `$$`
-      - BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png
+      - BC_BASEMAP_URL=https://services.pacificclimate.org/dev/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png
     entrypoint: /codebase/docker/local-run/entrypoint-fe.sh
     volumes:
       # This is to enable installing local versions of other packages from

--- a/docker/local-run/docker-compose.yaml
+++ b/docker/local-run/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - NA_TILES_URL=https://services.pacificclimate.org/dev/tiles/lite-wgs84
+      - NA_TILES_URL=https://services.pacificclimate.org/dev/mapproxy/service
       # In order to pass environment variables with *content* of the form
       # `${...}` through to JavaScript, the `$` must be escaped as `$$`
       - BC_BASEMAP_URL=https://services.pacificclimate.org/dev/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/docker/local-run/docker-compose.yaml
+++ b/docker/local-run/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - WGS84_URL=https://services.pacificclimate.org/tiles/lite-wgs84
       # In order to pass environment variables with *content* of the form
       # `${...}` through to JavaScript, the `$` must be escaped as `$$`
       - BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/docker/production/docker-compose-local.yaml
+++ b/docker/production/docker-compose-local.yaml
@@ -40,7 +40,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - WGS84_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - TILES_URL=https://services.pacificclimate.org/tiles
 
   backend:
     image: pcic/pdp-production

--- a/docker/production/docker-compose-local.yaml
+++ b/docker/production/docker-compose-local.yaml
@@ -40,7 +40,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILES_URL=https://services.pacificclimate.org/tiles
+      - NA_TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
 
   backend:
     image: pcic/pdp-production

--- a/docker/production/docker-compose-local.yaml
+++ b/docker/production/docker-compose-local.yaml
@@ -40,7 +40,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - NA_TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - NA_TILES_URL=https://services.pacificclimate.org/mapproxy/service
 
   backend:
     image: pcic/pdp-production

--- a/docker/production/docker-compose-local.yaml
+++ b/docker/production/docker-compose-local.yaml
@@ -40,7 +40,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - WGS84_URL=https://services.pacificclimate.org/tiles/lite-wgs84
 
   backend:
     image: pcic/pdp-production

--- a/docker/production/docker-compose-local.yaml
+++ b/docker/production/docker-compose-local.yaml
@@ -40,7 +40,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=http://docker-dev02.pcic.uvic.ca:30779/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILECACHE_URL=https://a.tile.pacificclimate.org/tilecache/tilecache.py https://b.tile.pacificclimate.org/tilecache/tilecache.py https://c.tile.pacificclimate.org/tilecache/tilecache.py
+      - TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
 
   backend:
     image: pcic/pdp-production

--- a/docker/production/docker-compose.yaml
+++ b/docker/production/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=NCWMS_URL=https://services.pacificclimate.org/ncwms-mm-rproxy/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - NA_TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - NA_TILES_URL=https://services.pacificclimate.org/mapproxy/service
     ports:
       - "8000:8000"  # frontend
     volumes:

--- a/docker/production/docker-compose.yaml
+++ b/docker/production/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=NCWMS_URL=https://services.pacificclimate.org/ncwms-mm-rproxy/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILECACHE_URL=https://a.tile.pacificclimate.org/tilecache/tilecache.py https://b.tile.pacificclimate.org/tilecache/tilecache.py https://c.tile.pacificclimate.org/tilecache/tilecache.py
+      - TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
     ports:
       - "8000:8000"  # frontend
     volumes:

--- a/docker/production/docker-compose.yaml
+++ b/docker/production/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=NCWMS_URL=https://services.pacificclimate.org/ncwms-mm-rproxy/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - WGS84_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - TILES_URL=https://services.pacificclimate.org/tiles
     ports:
       - "8000:8000"  # frontend
     volumes:

--- a/docker/production/docker-compose.yaml
+++ b/docker/production/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=NCWMS_URL=https://services.pacificclimate.org/ncwms-mm-rproxy/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
+      - WGS84_URL=https://services.pacificclimate.org/tiles/lite-wgs84
     ports:
       - "8000:8000"  # frontend
     volumes:

--- a/docker/production/docker-compose.yaml
+++ b/docker/production/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - GEOSERVER_URL=https://tools.pacificclimate.org/geoserver/
       - NCWMS_URL=NCWMS_URL=https://services.pacificclimate.org/ncwms-mm-rproxy/dynamic/x
       - OLD_NCWMS_URL=https://services.pacificclimate.org/ncWMS-PCIC/wms
-      - TILES_URL=https://services.pacificclimate.org/tiles
+      - NA_TILES_URL=https://services.pacificclimate.org/tiles/lite-wgs84
     ports:
       - "8000:8000"  # frontend
     volumes:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,7 +63,7 @@ They are loaded from the environment variables of the same name, upper cased.
 | `geoserver_url` | PCDS Geoserver URL |
 | `ncwms_url` | Raster portal ncWMS 2.x -- modelmeta translator URL. |
 | `old_ncwms_url` | Raster portal pure ncWMS 1.x URL. Used to fill in missing services from ncWMS 2.x. |
-| `tilecache_url` | Tileserver URLs (space separated list) for base maps |
+| `na_tiles_url` | MapProxy URL for serving North America base maps |
 | `bc_basemap_url` | Tile server URLs  (space separated list) for BC base maps
 | `use_analytics` | Enable or disable Google Analytics reporting |
 | `analytics` | Google Analytics ID |

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -38,7 +38,7 @@ def get_config_from_environment():
         'geoserver_url': 'http://tools.pacificclimate.org/geoserver/',
         'ncwms_url': 'http://tools.pacificclimate.org/ncWMS-PCIC/wms',
         'old_ncwms_url': 'https://services.pacificclimate.org/ncWMS-PCIC/',
-        'tiles_url': 'https://tools.pacificclimate.org/tiles',
+        'na_tiles_url': 'https://tools.pacificclimate.org/tiles/lite-wgs84',
         'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -38,7 +38,7 @@ def get_config_from_environment():
         'geoserver_url': 'http://tools.pacificclimate.org/geoserver/',
         'ncwms_url': 'http://tools.pacificclimate.org/ncWMS-PCIC/wms',
         'old_ncwms_url': 'https://services.pacificclimate.org/ncWMS-PCIC/',
-        'tiles_url': 'https://tools.pacificclimate.org/tiles/lite-wgs84',
+        'wgs84_url': 'https://tools.pacificclimate.org/tiles/lite-wgs84',
         'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -38,7 +38,7 @@ def get_config_from_environment():
         'geoserver_url': 'http://tools.pacificclimate.org/geoserver/',
         'ncwms_url': 'http://tools.pacificclimate.org/ncWMS-PCIC/wms',
         'old_ncwms_url': 'https://services.pacificclimate.org/ncWMS-PCIC/',
-        'na_tiles_url': 'https://tools.pacificclimate.org/tiles/lite-wgs84',
+        'na_tiles_url': 'https://tools.pacificclimate.org/mapproxy/service',
         'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -38,7 +38,7 @@ def get_config_from_environment():
         'geoserver_url': 'http://tools.pacificclimate.org/geoserver/',
         'ncwms_url': 'http://tools.pacificclimate.org/ncWMS-PCIC/wms',
         'old_ncwms_url': 'https://services.pacificclimate.org/ncWMS-PCIC/',
-        'na_tiles_url': 'https://tools.pacificclimate.org/mapproxy/service',
+        'na_tiles_url': 'https://services.pacificclimate.org/mapproxy/service',
         'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -38,10 +38,7 @@ def get_config_from_environment():
         'geoserver_url': 'http://tools.pacificclimate.org/geoserver/',
         'ncwms_url': 'http://tools.pacificclimate.org/ncWMS-PCIC/wms',
         'old_ncwms_url': 'https://services.pacificclimate.org/ncWMS-PCIC/',
-        'tilecache_url':
-            'http://a.tiles.pacificclimate.org/tilecache/tilecache.py'
-            ' http://b.tiles.pacificclimate.org/tilecache/tilecache.py'
-            ' http://c.tiles.pacificclimate.org/tilecache/tilecache.py',
+        'tiles_url': 'https://tools.pacificclimate.org/tiles/lite-wgs84',
         'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production
@@ -53,8 +50,6 @@ def get_config_from_environment():
     # evaluate a few config items that need to be objects (not strings)
     config['js_min'] = (config['js_min'] == 'True')
     config['use_analytics'] = (config['use_analytics'] == 'True')
-    if config['tilecache_url']:
-        config['tilecache_url'] = config['tilecache_url'].split()
     return config
 
 

--- a/pdp/__init__.py
+++ b/pdp/__init__.py
@@ -38,7 +38,7 @@ def get_config_from_environment():
         'geoserver_url': 'http://tools.pacificclimate.org/geoserver/',
         'ncwms_url': 'http://tools.pacificclimate.org/ncWMS-PCIC/wms',
         'old_ncwms_url': 'https://services.pacificclimate.org/ncWMS-PCIC/',
-        'wgs84_url': 'https://tools.pacificclimate.org/tiles/lite-wgs84',
+        'tiles_url': 'https://tools.pacificclimate.org/tiles',
         'bc_basemap_url': 'http://142.104.230.53:30790/osm-bc-lite-test/$${z}/$${x}/$${y}.png',
         'use_analytics': 'True',
         'analytics': 'UA-20166041-3'  # change for production

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -11,7 +11,7 @@ JS_MIN=false
 GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
-WGS84_URL=https://tools.pacificclimate.org/tiles/lite-wgs84
+TILES_URL=https://tools.pacificclimate.org/tiles
 # In order to pass environment variables with *content* of the form
 # `${...}` through to JavaScript, the `$` must be escaped as `$$`
 BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -11,7 +11,7 @@ JS_MIN=false
 GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
-TILECACHE_URL="http://a.tiles.pacificclimate.org/tilecache/tilecache.py http://b.tiles.pacificclimate.org/tilecache/tilecache.py http://c.tiles.pacificclimate.org/tilecache/tilecache.py"
+TILES_URL=https://tools.pacificclimate.org/tiles/lite-wgs84
 # In order to pass environment variables with *content* of the form
 # `${...}` through to JavaScript, the `$` must be escaped as `$$`
 BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -11,7 +11,7 @@ JS_MIN=false
 GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
-NA_TILES_URL=https://tools.pacificclimate.org/mapproxy/service
+NA_TILES_URL=https://services.pacificclimate.org/mapproxy/service
 # In order to pass environment variables with *content* of the form
 # `${...}` through to JavaScript, the `$` must be escaped as `$$`
 BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -11,7 +11,7 @@ JS_MIN=false
 GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
-TILES_URL=https://tools.pacificclimate.org/tiles/lite-wgs84
+WGS84_URL=https://tools.pacificclimate.org/tiles/lite-wgs84
 # In order to pass environment variables with *content* of the form
 # `${...}` through to JavaScript, the `$` must be escaped as `$$`
 BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -11,7 +11,7 @@ JS_MIN=false
 GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
-TILES_URL=https://tools.pacificclimate.org/tiles
+NA_TILES_URL=https://tools.pacificclimate.org/tiles/lite-wgs84
 # In order to pass environment variables with *content* of the form
 # `${...}` through to JavaScript, the `$` must be escaped as `$$`
 BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/pdp/config.env
+++ b/pdp/config.env
@@ -11,7 +11,7 @@ JS_MIN=false
 GEOSERVER_URL=http://tools.pacificclimate.org/geoserver/
 # change for development
 NCWMS_URL=http://tools.pacificclimate.org/ncWMS-PCIC/wms
-NA_TILES_URL=https://tools.pacificclimate.org/tiles/lite-wgs84
+NA_TILES_URL=https://tools.pacificclimate.org/mapproxy/service
 # In order to pass environment variables with *content* of the form
 # `${...}` through to JavaScript, the `$` must be escaped as `$$`
 BC_BASEMAP_URL=https://services.pacificclimate.org/tiles/bc-albers-lite/$${z}/$${x}/$${y}.png

--- a/pdp/static/css/map.css
+++ b/pdp/static/css/map.css
@@ -71,7 +71,7 @@ div.olPopup {
 }
 
 div.olMapViewport {
-    background-image: url(../images/water.png);
+    background-color: #aad3df;
 }
 
 div.olPopupContent {

--- a/pdp/static/js/__test__/app-test-helpers.js
+++ b/pdp/static/js/__test__/app-test-helpers.js
@@ -8,9 +8,7 @@ function initializeGlobals() {
         data_root: 'https://data.fake.org/data',
         gs_url: 'geoserver_url',
         ncwms_url: 'ncwms_url',
-        tilecache_url: [
-            'tilecache_url'
-        ],
+        na_tiles_url: 'na_tiles_url',
         'bc_basemap_url': 'bc_basemap_url',
         ensemble_name: 'ensemble_name',
     };

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'world_4326_osm', mapControls.projection);
+        na_osm = getTileBaseLayer(pdp.wgs84_url, 'North America OpenStreetMap', 'world_4326_osm', mapControls.projection);
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getTileBaseLayer(pdp.wgs84_url, 'North America OpenStreetMap', 'world_4326_osm', mapControls.projection);
+        na_osm = getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'lite-wgs84', mapControls.projection);
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getNaBaseLayer("http://docker-dev02.pcic.uvic.ca:30386/service", 'North America OpenStreetMap', 'cartoDB');
+        na_osm = getNaBaseLayer("https://services.pacificclimate.org/dev/mapproxy/service", 'North America OpenStreetMap', 'cartoDB');
         // na_osm = getNa4326LiteBaseLayer("https://cartodb-basemaps-a.global.ssl.fastly.net/light_all", 'North America OpenStreetMap');
 
         params = {

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -37,7 +37,6 @@
         map = new OpenLayers.Map("pdp-map", options);
 
         na_osm = getNaBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', 'osm');
-        // na_osm = getNa4326LiteBaseLayer("https://cartodb-basemaps-a.global.ssl.fastly.net/light_all", 'North America OpenStreetMap');
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNaBaseLayer, getOpacitySlider, Colorbar*/
+/*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getTileBaseLayer, getOpacitySlider, Colorbar*/
 
 /*
  * This map displays all-Canada pr, tasmin, and tasmax datasets.
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getNaBaseLayer(pdp.tilecache_url, 'North America OpenStreetMap', 'world_4326_osm', mapControls.projection);
+        na_osm = getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'world_4326_osm', mapControls.projection);
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getNaBaseLayer("https://services.pacificclimate.org/dev/mapproxy/service", 'North America OpenStreetMap', 'cartoDB');
+        na_osm = getNaBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', 'osm');
         // na_osm = getNa4326LiteBaseLayer("https://cartodb-basemaps-a.global.ssl.fastly.net/light_all", 'North America OpenStreetMap');
 
         params = {

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getTileBaseLayer, getOpacitySlider, Colorbar*/
+/*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNa4326LiteBaseLayer, getOpacitySlider, Colorbar*/
 
 /*
  * This map displays all-Canada pr, tasmin, and tasmax datasets.
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getTileBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', '', mapControls.projection);
+        na_osm = getNa4326LiteBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap');
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getNaBaseLayer("http://127.0.0.1:8080/service", 'North America OpenStreetMap', 'cartoDB');
+        na_osm = getNaBaseLayer("http://docker-dev02.pcic.uvic.ca:30386/service", 'North America OpenStreetMap', 'cartoDB');
         // na_osm = getNa4326LiteBaseLayer("https://cartodb-basemaps-a.global.ssl.fastly.net/light_all", 'North America OpenStreetMap');
 
         params = {

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -36,7 +36,7 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'lite-wgs84', mapControls.projection);
+        na_osm = getTileBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', '', mapControls.projection);
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/canada_ex_map.js
+++ b/pdp/static/js/canada_ex_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNa4326LiteBaseLayer, getOpacitySlider, Colorbar*/
+/*global $, jQuery, OpenLayers, pdp, map, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNaBaseLayer, getTileBaseLayer, getNa4326LiteBaseLayer, getOpacitySlider, Colorbar*/
 
 /*
  * This map displays all-Canada pr, tasmin, and tasmax datasets.
@@ -36,7 +36,8 @@
         options.controls = mapControls;
         map = new OpenLayers.Map("pdp-map", options);
 
-        na_osm = getNa4326LiteBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap');
+        na_osm = getNaBaseLayer("http://127.0.0.1:8080/service", 'North America OpenStreetMap', 'cartoDB');
+        // na_osm = getNa4326LiteBaseLayer("https://cartodb-basemaps-a.global.ssl.fastly.net/light_all", 'North America OpenStreetMap');
 
         params = {
             layers: initialMap.dataset + "/" + initialMap.variable,

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getNa4326LiteBaseLayer, getOpacitySlider*/
+/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getNaBaseLayer, getNa4326LiteBaseLayer, getOpacitySlider*/
 
 "use strict";
 
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getNa4326LiteBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap')
+            getNaBaseLayer("http://docker-dev02.pcic.uvic.ca:30386/service", 'North America OpenStreetMap', 'cartoDB')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getNaBaseLayer("http://docker-dev02.pcic.uvic.ca:30386/service", 'North America OpenStreetMap', 'cartoDB')
+            getNaBaseLayer("https://services.pacificclimate.org/dev/mapproxy/service", 'North America OpenStreetMap', 'cartoDB')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'world_4326_osm')
+            getTileBaseLayer(pdp.wgs84_url, 'North America OpenStreetMap', 'world_4326_osm')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getNaBaseLayer("https://services.pacificclimate.org/dev/mapproxy/service", 'North America OpenStreetMap', 'cartoDB')
+            getNaBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', 'osm')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getTileBaseLayer, getOpacitySlider*/
+/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getNa4326LiteBaseLayer, getOpacitySlider*/
 
 "use strict";
 
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getTileBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', '')
+            getNa4326LiteBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getTileBaseLayer(pdp.wgs84_url, 'North America OpenStreetMap', 'world_4326_osm')
+            getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'lite-wgs84')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'lite-wgs84')
+            getTileBaseLayer(pdp.na_tiles_url, 'North America OpenStreetMap', '')
         ]
     );
 

--- a/pdp/static/js/gridded_observations_map.js
+++ b/pdp/static/js/gridded_observations_map.js
@@ -1,5 +1,5 @@
 /*jslint browser: true, devel: true */
-/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getNaBaseLayer, getOpacitySlider*/
+/*global $, jQuery, OpenLayers, pdp, Colorbar, na4326_map_options, getBasicControls, getBoxLayer, getEditingToolbar, getHandNav, getBoxEditor, getNA4326Bounds, getTileBaseLayer, getOpacitySlider*/
 
 "use strict";
 
@@ -54,7 +54,7 @@ function init_obs_map() {
         [
             ncwms,
             selectionLayer,
-            getNaBaseLayer(pdp.tilecache_url, 'North America OpenStreetMap', 'world_4326_osm')
+            getTileBaseLayer(pdp.tiles_url, 'North America OpenStreetMap', 'world_4326_osm')
         ]
     );
 

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -154,10 +154,11 @@ function getNaBaseLayer(wmsurl, displayname, layername, proj) {
         wmsurl,
         {
             layers: layername,
-            format: "image/png"
+            transparent: "true"
         },
         {
             projection: proj,
+            isBaseLayer: true,
             maxResolution: 1.40625,
             numZoomLevels: 10,
             attribution: '© OpenStreetMap contributors'

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -210,6 +210,20 @@ function getBC3005BCLiteBaseLayer(url, displayname) {
   );
 }
 
+function getNa4326LiteBaseLayer(url, displayname) {
+  return new OpenLayers.Layer.XYZ(
+    displayname,
+    url + "/${z}/${x}/${y}.png",
+    {
+      projection: getProjection(4326),
+      units: 'degrees',
+      maxExtent: getNA4326Bounds(),
+      numZoomLevels: 7,
+      attribution: '© OpenStreetMap contributors'
+    }
+  );
+}
+
 function getBasicControls() {
     return [
         new OpenLayers.Control.LayerSwitcher({'ascending': false}),

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -400,6 +400,7 @@ condExport(module, {
     getTileBaseLayer: getTileBaseLayer,
     getBC3005OsmBaseLayer: getBC3005OsmBaseLayer,
     getBC3005BCLiteBaseLayer: getBC3005BCLiteBaseLayer,
+    getNa4326LiteBaseLayer: getNa4326LiteBaseLayer,
     getBasicControls: getBasicControls,
     getEditingToolbar: getEditingToolbar,
     getHandNav: getHandNav,

--- a/pdp/static/js/pdp_map.js
+++ b/pdp/static/js/pdp_map.js
@@ -154,6 +154,7 @@ function getNaBaseLayer(wmsurl, displayname, layername, proj) {
         wmsurl,
         {
             layers: layername,
+            format: "image/png"
         },
         {
             projection: proj,

--- a/pdp/templates/map.html
+++ b/pdp/templates/map.html
@@ -20,7 +20,7 @@
           gs_url: '${geoserver_url}',
           ncwms_url: '${ncwms_url}',
           old_ncwms_url: '${old_ncwms_url}',
-          tiles_url: '${tiles_url}',
+          wgs84_url: '${wgs84_url}',
           bc_basemap_url: '${bc_basemap_url}',
           ensemble_name: '${ensemble_name}'
         };

--- a/pdp/templates/map.html
+++ b/pdp/templates/map.html
@@ -20,7 +20,7 @@
           gs_url: '${geoserver_url}',
           ncwms_url: '${ncwms_url}',
           old_ncwms_url: '${old_ncwms_url}',
-          tiles_url: '${tiles_url}',
+          na_tiles_url: '${na_tiles_url}',
           bc_basemap_url: '${bc_basemap_url}',
           ensemble_name: '${ensemble_name}'
         };

--- a/pdp/templates/map.html
+++ b/pdp/templates/map.html
@@ -20,7 +20,7 @@
           gs_url: '${geoserver_url}',
           ncwms_url: '${ncwms_url}',
           old_ncwms_url: '${old_ncwms_url}',
-          wgs84_url: '${wgs84_url}',
+          tiles_url: '${tiles_url}',
           bc_basemap_url: '${bc_basemap_url}',
           ensemble_name: '${ensemble_name}'
         };

--- a/pdp/templates/map.html
+++ b/pdp/templates/map.html
@@ -13,10 +13,6 @@
       it can be imported here using the syntax `name: '${name}'`, as below.
       -->
       <script type="text/javascript">
-      var tcUrls = new Array();
-      <py:for each="url in tilecache_url">
-        tcUrls.push('${url}');
-      </py:for>
         var pdp = {
           VERSION: '0.1',
           app_root: '${app_root}',
@@ -24,7 +20,7 @@
           gs_url: '${geoserver_url}',
           ncwms_url: '${ncwms_url}',
           old_ncwms_url: '${old_ncwms_url}',
-          tilecache_url: tcUrls,
+          tiles_url: '${tiles_url}',
           bc_basemap_url: '${bc_basemap_url}',
           ensemble_name: '${ensemble_name}'
         };


### PR DESCRIPTION
This PR resolves #298. This replaces the uses of Tilecache with PCIC's configuration of [MapProxy](https://mapproxy.org/), which serves basemap tiles from [OpenStreetMap](https://www.openstreetmap.org) in the North America portals.

Demo available [here](https://services.pacificclimate.org/dev/portal/downscaled_cmip6/map/).

## Checklist
- [x] Full integration tests are passing locally
- [x] Docs have been updated to reflect the changes